### PR TITLE
fix(ui): menu lateral para ações e sem sobreposição

### DIFF
--- a/src/app/app-content-wrapper.tsx
+++ b/src/app/app-content-wrapper.tsx
@@ -19,6 +19,7 @@ import DevInfoIndicator from '@/components/layout/dev-info-indicator';
 import SubscriptionForm from '@/components/subscription-form'; 
 import { ThemeProvider } from '@/components/theme-provider';
 import FloatingSupportButtons from '@/components/support/floating-support-buttons';
+import { FloatingActionsProvider } from '@/components/floating-actions/floating-actions-provider';
 import { cn } from '@/lib/utils';
 
 export function AppContentWrapper({ 
@@ -64,27 +65,29 @@ export function AppContentWrapper({
       enableSystem
       disableTransitionOnChange
     >
-      <SetupRedirect isSetupComplete={isSetupComplete} />
-      <div className="flex flex-col min-h-screen">
-        <Suspense fallback={<div className="flex items-center justify-center h-24 border-b"><Loader2 className="h-6 w-6 animate-spin" /></div>}>
-            <Header 
-              platformSettings={platformSettings}
-            />
-        </Suspense>
-        <main
-          className={cn(
-            'flex-grow w-full transition-all duration-300',
-            isMapSearchPage ? 'max-w-[1680px] mx-auto px-2 sm:px-6 lg:px-10 py-6' : 'container mx-auto px-4 py-8'
-          )}
-          data-ai-id="main-content"
-          data-layout={isMapSearchPage ? 'map-search' : 'default'}
-        >
-          {children}
-        </main>
-        <SubscriptionForm />
-        <Footer />
-        <FloatingSupportButtons />
-      </div>
+      <FloatingActionsProvider>
+        <SetupRedirect isSetupComplete={isSetupComplete} />
+        <div className="flex flex-col min-h-screen">
+          <Suspense fallback={<div className="flex items-center justify-center h-24 border-b"><Loader2 className="h-6 w-6 animate-spin" /></div>}>
+              <Header 
+                platformSettings={platformSettings}
+              />
+          </Suspense>
+          <main
+            className={cn(
+              'flex-grow w-full transition-all duration-300',
+              isMapSearchPage ? 'max-w-[1680px] mx-auto px-2 sm:px-6 lg:px-10 py-6' : 'container mx-auto px-4 py-8'
+            )}
+            data-ai-id="main-content"
+            data-layout={isMapSearchPage ? 'map-search' : 'default'}
+          >
+            {children}
+          </main>
+          <SubscriptionForm />
+          <Footer />
+          <FloatingSupportButtons />
+        </div>
+      </FloatingActionsProvider>
     </ThemeProvider>
   );
 }

--- a/src/app/auctioneers/[auctioneerSlug]/page.tsx
+++ b/src/app/auctioneers/[auctioneerSlug]/page.tsx
@@ -36,6 +36,7 @@ import { hasAnyPermission } from '@/lib/permissions';
 import { isValidImageUrl } from '@/lib/ui-helpers';
 import BidExpertCard from '@/components/BidExpertCard';
 import BidExpertListItem from '@/components/BidExpertListItem';
+import { useFloatingActions } from '@/components/floating-actions/floating-actions-provider';
 
 // Sort options for auctions (similar to search page)
 const sortOptionsAuctions = [
@@ -71,6 +72,7 @@ export default function AuctioneerDetailsPage() {
   const auctioneerSlug = typeof params.auctioneerSlug === 'string' ? params.auctioneerSlug : '';
 
   const { userProfileWithPermissions } = useAuth();
+  const { setPageActions } = useFloatingActions();
   const [auctioneerProfile, setAuctioneerProfile] = useState<AuctioneerProfileInfo | null>(null);
   const [relatedAuctions, setRelatedAuctions] = useState<Auction[]>([]);
   const [isLoading, setIsLoading] = useState(true);
@@ -90,6 +92,25 @@ export default function AuctioneerDetailsPage() {
     hasAnyPermission(userProfileWithPermissions, ['manage_all', 'auctioneers:update']),
     [userProfileWithPermissions]
   );
+
+  useEffect(() => {
+    if (!hasEditPermissions || !auctioneerProfile?.id) {
+      setPageActions([]);
+      return;
+    }
+
+    setPageActions([
+      {
+        id: 'edit-auctioneer',
+        label: 'Editar Leiloeiro',
+        href: `/admin/auctioneers/${auctioneerProfile.id}/edit`,
+        icon: Pencil,
+        dataAiId: 'floating-action-edit-auctioneer',
+      },
+    ]);
+
+    return () => setPageActions([]);
+  }, [auctioneerProfile?.id, hasEditPermissions, setPageActions]);
 
   useEffect(() => {
     async function fetchAuctioneerDetails() {
@@ -232,7 +253,6 @@ export default function AuctioneerDetailsPage() {
   const placeholderTeamReviews = Math.floor(Math.random() * 500 + 50);
   const placeholderAveragePrice = ((Math.random() * 500 + 100) * 1000).toLocaleString('pt-BR', { style: 'currency', currency: 'BRL', minimumFractionDigits: 0, maximumFractionDigits: 0 }).replace(/\s/g, '');
   const placeholderPriceRange = `${((Math.random() * 50 + 10) * 1000).toLocaleString('pt-BR', { style: 'currency', currency: 'BRL', minimumFractionDigits: 0, maximumFractionDigits: 0 }).replace(/\s/g, '')} - ${((Math.random() * 2000 + 500) * 1000).toLocaleString('pt-BR', { style: 'currency', currency: 'BRL', minimumFractionDigits: 0, maximumFractionDigits: 0 }).replace(/\s/g, '')}`;
-  const editUrl = `/admin/auctioneers/${auctioneerProfile.id}/edit`;
   const validLogoUrl = isValidImageUrl(auctioneerProfile.logoUrl) ? auctioneerProfile.logoUrl! : `https://placehold.co/160x160.png?text=${auctioneerInitial}`;
   const fullAddress = [auctioneerProfile.street, auctioneerProfile.number, auctioneerProfile.complement, auctioneerProfile.neighborhood, auctioneerProfile.city, auctioneerProfile.state, auctioneerProfile.zipCode].filter(Boolean).join(', ');
 
@@ -360,23 +380,6 @@ export default function AuctioneerDetailsPage() {
       </div>
     </TooltipProvider>
 
-    {hasEditPermissions && auctioneerProfile?.id && (
-      <TooltipProvider>
-        <Tooltip>
-          <TooltipTrigger asChild>
-            <Button asChild className="fixed bottom-16 right-5 z-50 h-14 w-14 rounded-full shadow-lg" size="icon" data-ai-id="auctioneer-edit-fab">
-              <Link href={editUrl}>
-                <Pencil className="h-6 w-6" />
-                <span className="sr-only">Editar Leiloeiro</span>
-              </Link>
-            </Button>
-          </TooltipTrigger>
-          <TooltipContent side="left">
-            <p>Editar Leiloeiro</p>
-          </TooltipContent>
-        </Tooltip>
-      </TooltipProvider>
-    )}
   </>
   );
 }

--- a/src/app/auctions/[auctionId]/auction-details-client.tsx
+++ b/src/app/auctions/[auctionId]/auction-details-client.tsx
@@ -35,6 +35,7 @@ import { hasAnyPermission } from '@/lib/permissions';
 import { Tooltip, TooltipProvider, TooltipTrigger, TooltipContent } from '@/components/ui/tooltip';
 import BidExpertCard from '@/components/BidExpertCard';
 import BidExpertListItem from '@/components/BidExpertListItem';
+import { useFloatingActions } from '@/components/floating-actions/floating-actions-provider';
 
 
 const SidebarFilter = dynamic(() => import('@/components/BidExpertFilter'), {
@@ -82,11 +83,30 @@ export default function AuctionDetailsClient({ auction, auctioneer, platformSett
   const [isFilterSheetOpen, setIsFilterSheetOpen] = useState(false);
 
   const { userProfileWithPermissions } = useAuth();
+  const { setPageActions } = useFloatingActions();
   const hasEditPermissions = useMemo(() => 
     hasAnyPermission(userProfileWithPermissions, ['manage_all', 'auctions:update']),
     [userProfileWithPermissions]
   );
-  const editUrl = `/admin/auctions/${auction.id}/edit`;
+
+  useEffect(() => {
+    if (!hasEditPermissions) {
+      setPageActions([]);
+      return;
+    }
+
+    setPageActions([
+      {
+        id: 'edit-auction',
+        label: 'Editar Leilão',
+        href: `/admin/auctions/${auction.id}/edit`,
+        icon: Pencil,
+        dataAiId: 'floating-action-edit-auction',
+      },
+    ]);
+
+    return () => setPageActions([]);
+  }, [auction.id, hasEditPermissions, setPageActions]);
 
   // State for lot filtering and sorting
   const [activeFilters, setActiveFilters] = useState<ActiveFilters>(initialFiltersState);
@@ -364,23 +384,6 @@ export default function AuctionDetailsClient({ auction, auctioneer, platformSett
         </div>
 
       </div>
-      {hasEditPermissions && (
-        <TooltipProvider>
-          <Tooltip>
-            <TooltipTrigger asChild>
-              <Button asChild className="fixed bottom-16 right-5 z-50 h-14 w-14 rounded-full shadow-lg" size="icon">
-                <Link href={editUrl}>
-                  <Pencil className="h-6 w-6" />
-                  <span className="sr-only">Editar Leilão</span>
-                </Link>
-              </Button>
-            </TooltipTrigger>
-            <TooltipContent side="left">
-              <p>Editar Leilão</p>
-            </TooltipContent>
-          </Tooltip>
-        </TooltipProvider>
-      )}
     </>
   );
 }

--- a/src/app/auctions/[auctionId]/lots/[lotId]/lot-detail-client.tsx
+++ b/src/app/auctions/[auctionId]/lots/[lotId]/lot-detail-client.tsx
@@ -57,6 +57,7 @@ import LotQuestionsTab from '@/components/auction/lot-questions-tab';
 import LotPreviewModal from '@/components/lot-preview-modal';
 import { hasAnyPermission, hasPermission } from '@/lib/permissions';
 import { cn } from '@/lib/utils';
+import { useFloatingActions } from '@/components/floating-actions/floating-actions-provider';
 import LotAllBidsModal from '@/components/auction/lot-all-bids-modal';
 import { Switch } from '@/components/ui/switch';
 import { Label } from '@/components/ui/label';
@@ -313,6 +314,7 @@ export default function LotDetailClientContent({
   const { toast } = useToast();
   const [currentUrl, setCurrentUrl] = useState('');
   const { userProfileWithPermissions, loading: authLoading } = useAuth();
+  const { setPageActions } = useFloatingActions();
   const [lotReviews, setLotReviews] = useState<Review[]>([]);
   const [lotQuestions, setLotQuestions] = useState<LotQuestion[]>([]);
   const [lotDocuments, setLotDocuments] = useState<LotDocument[]>([]);
@@ -385,7 +387,25 @@ export default function LotDetailClientContent({
     hasAnyPermission(userProfileWithPermissions, ['manage_all', 'lots:update']),
     [userProfileWithPermissions]
   );
-  const editUrl = `/admin/lots/${lot.id}/edit`;
+
+  useEffect(() => {
+    if (!hasEditPermissions) {
+      setPageActions([]);
+      return;
+    }
+
+    setPageActions([
+      {
+        id: 'edit-lot',
+        label: 'Editar Lote',
+        href: `/admin/lots/${lot.id}/edit`,
+        icon: Pencil,
+        dataAiId: 'floating-action-edit-lot',
+      },
+    ]);
+
+    return () => setPageActions([]);
+  }, [hasEditPermissions, lot.id, setPageActions]);
   
   const gallery = useMemo(() => {
     if (!lot) return [];
@@ -887,23 +907,6 @@ export default function LotDetailClientContent({
             </section>
           )}
         </div>
-        {hasEditPermissions && (
-          <TooltipProvider>
-            <Tooltip>
-              <TooltipTrigger asChild>
-                <Button asChild className="fixed bottom-16 right-5 z-50 h-14 w-14 rounded-full shadow-lg" size="icon">
-                  <Link href={editUrl}>
-                    <Pencil className="h-6 w-6" />
-                    <span className="sr-only">Editar Lote</span>
-                  </Link>
-                </Button>
-              </TooltipTrigger>
-              <TooltipContent side="left">
-                <p>Editar Lote</p>
-              </TooltipContent>
-            </Tooltip>
-          </TooltipProvider>
-        )}
       </TooltipProvider>
 
       <LotPreviewModal lot={lot} auction={auction} platformSettings={platformSettings} isOpen={isPreviewModalOpen} onClose={() => setIsPreviewModalOpen(false)} />

--- a/src/components/floating-actions/floating-actions-provider.tsx
+++ b/src/components/floating-actions/floating-actions-provider.tsx
@@ -1,0 +1,52 @@
+/**
+ * @fileoverview Provider de ações flutuantes para páginas públicas.
+ * Permite que páginas registrem ações contextuais (ex.: "Editar") que serão exibidas
+ * no menu lateral flutuante global.
+ */
+
+'use client';
+
+import React, { createContext, useCallback, useContext, useMemo, useState } from 'react';
+import type { LucideIcon } from 'lucide-react';
+
+export type FloatingAction = {
+  id: string;
+  label: string;
+  icon: LucideIcon;
+  href?: string;
+  onSelect?: () => void;
+  dataAiId?: string;
+};
+
+type FloatingActionsContextValue = {
+  pageActions: FloatingAction[];
+  setPageActions: (actions: FloatingAction[]) => void;
+};
+
+const FloatingActionsContext = createContext<FloatingActionsContextValue | null>(null);
+
+export function FloatingActionsProvider({ children }: { children: React.ReactNode }) {
+  const [pageActions, setPageActionsState] = useState<FloatingAction[]>([]);
+
+  const setPageActions = useCallback((actions: FloatingAction[]) => {
+    setPageActionsState(actions);
+  }, []);
+
+  const value = useMemo(
+    () => ({
+      pageActions,
+      setPageActions,
+    }),
+    [pageActions, setPageActions]
+  );
+
+  return <FloatingActionsContext.Provider value={value}>{children}</FloatingActionsContext.Provider>;
+}
+
+export function useFloatingActions() {
+  const ctx = useContext(FloatingActionsContext);
+  if (!ctx) {
+    throw new Error('useFloatingActions must be used within FloatingActionsProvider');
+  }
+  return ctx;
+}


### PR DESCRIPTION
## Contexto\nOs botões flutuantes (suporte + editar) estavam se sobrepondo e bloqueando o clique do botão de edição.\n\n## O que mudou\n- Substitui FABs por um menu lateral (Sheet) único no canto inferior direito\n- Ações de suporte (FAQ/Chat AI/Reportar) ficam no menu\n- Ações contextuais de página (ex.: Editar) são registradas via provider e aparecem no menu\n\n## Arquivos principais\n- src/components/support/floating-support-buttons.tsx\n- src/components/floating-actions/floating-actions-provider.tsx\n- src/app/app-content-wrapper.tsx\n\n## Observação\nO 
pm run typecheck está falhando no workspace por erros em src/services/* (não relacionados a este PR).