### PR TITLE
fix(skills): padroniza frontmatter das skills

### DIFF
--- a/.github/skills/media-library/SKILL.md
+++ b/.github/skills/media-library/SKILL.md
@@ -1,4 +1,9 @@
-﻿# Media Library (Google Photos-like) ÔÇö Skill
+﻿---
+name: media-library
+description: Biblioteca de mídia administrativa com galeria, vínculos de entidades, editor de imagem e storage dual-adapter no BidExpert.
+---
+
+# Media Library (Google Photos-like) ÔÇö Skill
 
 > **Scope**: Biblioteca de M├¡dia admin com galeria responsiva, entidades vinculadas, editor de imagem Canvas API, lightbox, e storage dual-adapter.
 

--- a/.github/skills/multi-environment/SKILL.md
+++ b/.github/skills/multi-environment/SKILL.md
@@ -1,3 +1,8 @@
+---
+name: multi-environment
+description: Workflow de isolamento de ambientes DEV, DEMO e PROD com regras de branch, portas e compatibilidade de banco para o BidExpert.
+---
+
 # 🔀 Skill: Multi-Environment Workflow (DEV ↔ DEMO ↔ PROD)
 
 ## Descrição

--- a/.github/skills/observability-audit/SKILL.md
+++ b/.github/skills/observability-audit/SKILL.md
@@ -1,3 +1,8 @@
+---
+name: observability-audit
+description: Diretrizes de observabilidade e auditoria 360 com OpenTelemetry, Prisma Audit Extension e rastreabilidade por traceId.
+---
+
 # Observability & Audit Architect (360º) - AI Agent Skill
 
 ## 1. Persona and Objectives

--- a/.github/skills/report-builder/SKILL.md
+++ b/.github/skills/report-builder/SKILL.md
@@ -1,3 +1,8 @@
+---
+name: report-builder
+description: Implementação e evolução do módulo Report Builder com GrapesJS, Handlebars e renderização PDF via Puppeteer.
+---
+
 # Skill: Report Builder (GrapesJS + Puppeteer + Handlebars)
 
 ## Descrição

--- a/.github/skills/vercel-postgresql-deploy/SKILL.md
+++ b/.github/skills/vercel-postgresql-deploy/SKILL.md
@@ -1,3 +1,8 @@
+---
+name: vercel-postgresql-deploy
+description: Regras críticas de deploy Vercel com PostgreSQL e Prisma para evitar falhas de build, middleware e compatibilidade de queries.
+---
+
 # 🚀 Skill: Vercel + PostgreSQL Deploy & Compatibility
 
 ## Descrição

--- a/.github/skills/web-design-reviewer/SKILL.md
+++ b/.github/skills/web-design-reviewer/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: web-design-reviewer
-description: 'This skill enables visual inspection of websites running locally or remotely to identify and fix design issues. Triggers on requests like "review website design", "check the UI", "fix the layout", "find design problems". Detects issues with responsive design, accessibility, visual consistency, and layout breakage, then performs fixes at the source code level.'
+description: This skill enables visual inspection of websites to detect and fix responsive, accessibility, visual consistency, and layout issues at source code level.
 ---
 
 # Web Design Reviewer


### PR DESCRIPTION
## Resumo\n- adiciona/normaliza frontmatter YAML nas skills para garantir carregamento pelo Chat Customization Diagnostics\n- padroniza campos obrigatórios 
ame e description\n\n## Arquivos\n- .github/skills/media-library/SKILL.md\n- .github/skills/multi-environment/SKILL.md\n- .github/skills/observability-audit/SKILL.md\n- .github/skills/report-builder/SKILL.md\n- .github/skills/vercel-postgresql-deploy/SKILL.md\n- .github/skills/web-design-reviewer/SKILL.md\n\n## Validação\n- conferido via busca que 7/7 skills possuem 
ame e description no frontmatter