### PR TITLE
fix: Corrigir referência a JudicialDistrict em judicial-branch.service.ts

### DIFF
--- a/src/services/judicial-branch.service.ts
+++ b/src/services/judicial-branch.service.ts
@@ -24,8 +24,8 @@ export class JudicialBranchService {
     const branches = await this.repository.findAll();
     return branches.map(b => ({
       ...b,
-      districtName: b.district.name,
-      stateUf: b.district.state?.uf,
+      districtName: b.JudicialDistrict?.name || '',
+      stateUf: b.JudicialDistrict?.State?.uf || '',
     }));
   }
 
@@ -34,8 +34,8 @@ export class JudicialBranchService {
     if (!branch) return null;
     return {
       ...branch,
-      districtName: branch.district.name,
-      stateUf: branch.district.state?.uf,
+      districtName: branch.JudicialDistrict?.name || '',
+      stateUf: branch.JudicialDistrict?.State?.uf || '',
     };
   }
 


### PR DESCRIPTION
Corrige o erro que impedia a página de sellers (\/admin/sellers\) de carregar no Vercel.

## Problema
- TypeError: Cannot read properties of undefined (reading 'name')
- Ocorria em \getJudicialBranches()\ ao mapear resultados do Prisma
- Causa raiz: Referência incorreta a 'b.district' quando Prisma retorna 'b.JudicialDistrict'

## Solução
- Corrigir nomes de propriedades para corresponder exatamente ao schema Prisma (PascalCase)
- Adicionar null-safety com optional chaining
- Aplicado em ambas as funções: getJudicialBranches() e getJudicialBranchById()

## Validação
- Testado em container sandbox isolado
- Página carrega sem erro
- Sem mensagens de erro nos logs

## Arquivos Alterados
- src/services/judicial-branch.service.ts