### PR TITLE
fix: Corrigir TypeError em CityRepository.upsert - referência State PascalCase

### DIFF
--- a/src/repositories/city.repository.ts
+++ b/src/repositories/city.repository.ts
@@ -38,9 +38,17 @@ export class CityRepository {
   }
 
   async upsert(data: Prisma.CityCreateInput): Promise<CityInfo> {
+    const stateConnect = (data as any).State?.connect ?? (data as any).state?.connect;
+    if (!stateConnect?.id) {
+      throw new Error('State connection is required for city upsert');
+    }
     return prisma.city.upsert({
-      where: { name_stateId: { name: data.name, stateId: data.state.connect.id } },
-      update: data,
+      where: { name_stateId: { name: data.name, stateId: stateConnect.id } },
+      update: {
+        name: data.name,
+        slug: data.slug,
+        ibgeCode: data.ibgeCode,
+      },
       create: data,
     });
   }


### PR DESCRIPTION
## Problema
- **TypeError**: `Cannot read properties of undefined (reading 'connect')`
- Ocorria em `CityRepository.upsert()` ao salvar uma cidade nova no Vercel (PostgreSQL)
- Causa raiz: O método acessava `data.state.connect.id` (lowercase) mas o Prisma gera `State` (PascalCase) conforme definido no schema

## Solução
- Acessar `data.State?.connect` com fallback para `data.state?.connect` (compatibilidade)
- Separar campos escalares no `update` do upsert para evitar conflitos com relação `State: { connect: ... }`
- Adicionar validação de null-safety antes do upsert

## Arquivo Alterado
- `src/repositories/city.repository.ts`

## Validação
- Análise do schema Prisma confirma relação `State` (PascalCase) em ambos schemas (MySQL e PostgreSQL)