### PR TITLE
fix(ci-cd): monitor active workflow names for issue creation

### DIFF
--- a/.github/workflows/create-issue-on-failure.yml
+++ b/.github/workflows/create-issue-on-failure.yml
@@ -4,6 +4,8 @@ name: Create Issue on CI/CD Failure
 on:
   workflow_run:
     workflows: 
+      - "CI - Pull Request Checks"
+      - "Deploy DEMO to Vercel"
       - "P0 CI Pipeline"
       - "Deploy to Demo (Vercel)"
       - "Deploy to HML (Vercel)"


### PR DESCRIPTION
## O que muda\n- adiciona os nomes reais dos workflows atuais no trigger workflow_run:\n  - CI - Pull Request Checks\n  - Deploy DEMO to Vercel\n\n## Motivo\nSem isso, falhas atuais não disparam criação automática de issue.