### PR TITLE
fix(supergrid): corrigir erros de runtime e tipos TypeScript no SuperGrid

### DIFF
--- a/src/app/auth/actions.ts
+++ b/src/app/auth/actions.ts
@@ -263,7 +263,8 @@ export async function getDevUsers(): Promise<Array<{ email: string; fullName: st
       take: 15,
       orderBy: { createdAt: 'asc' },
       include: {
-        Tenant: true,
+        UsersOnRoles: { include: { Role: true } },
+        UsersOnTenants: { include: { Tenant: true } },
       }
     });
 
@@ -280,10 +281,10 @@ export async function getDevUsers(): Promise<Array<{ email: string; fullName: st
 
       return {
         email: u.email,
-        fullName: u.name || 'Unknown',
-        roleName: u.role,
+        fullName: u.fullName || 'Unknown',
+        roleName: u.UsersOnRoles?.[0]?.Role?.name ?? 'Unknown',
         passwordHint: passwordHint,
-        tenantId: u.tenantId?.toString() || '1'
+        tenantId: u.UsersOnTenants?.[0]?.tenantId?.toString() || '1'
       };
     });
   } catch (error) {

--- a/src/components/super-grid/SuperGrid.types.ts
+++ b/src/components/super-grid/SuperGrid.types.ts
@@ -7,6 +7,7 @@
 
 import { z } from 'zod';
 import type { ReactNode, ComponentType } from 'react';
+import type { GridLocale } from './SuperGrid.i18n';
 
 // ==========================================
 // 1. TIPOS BÁSICOS DE CAMPO
@@ -256,6 +257,23 @@ export interface SuperGridConfig<TEntity = Record<string, unknown>> {
     onRowClick?: (row: TEntity) => void;
     onSelectionChange?: (rows: TEntity[]) => void;
     onError?: (error: Error) => void;
+  };
+
+  // Internacionalização
+  locale?: GridLocale;
+
+  // Destaque visual
+  highlight?: {
+    activeRow?: boolean;
+    stripedRows?: boolean;
+    columnHover?: boolean;
+    rules?: Array<{ condition: (row: TEntity) => boolean; className: string }>;
+  };
+
+  // Congelamento de painéis
+  freezePanes?: {
+    enabled?: boolean;
+    showDividerShadow?: boolean;
   };
 }
 

--- a/src/components/super-grid/hooks/useGridState.ts
+++ b/src/components/super-grid/hooks/useGridState.ts
@@ -58,9 +58,16 @@ export function useGridState<TEntity>(config: SuperGridConfig<TEntity>) {
     rules: [],
   });
 
-  // Edição
+  // Edição de linha (modal / inline row)
   const [editingRow, setEditingRow] = useState<TEntity | null>(null);
   const [isAddingNew, setIsAddingNew] = useState(false);
+
+  // Edição de célula (inline cell mode)
+  const [editingCellId, setEditingCellId] = useState<{ rowId: string; columnId: string } | null>(null);
+  const [editingCellValue, setEditingCellValue] = useState<unknown>(undefined);
+
+  // Coluna com hover destacado
+  const [hoveredColumnId, setHoveredColumnId] = useState<string | null>(null);
 
   // Reset de paginação quando filtros mudam
   const handleGlobalFilterChange = (value: string) => {
@@ -72,6 +79,16 @@ export function useGridState<TEntity>(config: SuperGridConfig<TEntity>) {
     setQueryBuilderState(query);
     setPagination(prev => ({ ...prev, pageIndex: 0 }));
   };
+
+  function startCellEdit(rowId: string, columnId: string, value: unknown) {
+    setEditingCellId({ rowId, columnId });
+    setEditingCellValue(value);
+  }
+
+  function cancelCellEdit() {
+    setEditingCellId(null);
+    setEditingCellValue(undefined);
+  }
 
   return {
     pagination,
@@ -98,5 +115,11 @@ export function useGridState<TEntity>(config: SuperGridConfig<TEntity>) {
     setEditingRow,
     isAddingNew,
     setIsAddingNew,
+    editingCellId,
+    editingCellValue,
+    startCellEdit,
+    cancelCellEdit,
+    hoveredColumnId,
+    setHoveredColumnId,
   };
 }


### PR DESCRIPTION
## Problema

Três bugs identificados via console do browser e typecheck:

### Bug 1 — \setHoveredColumnId is not a function\ (runtime)
- **Arquivo:** \useGridState.ts\
- **Causa:** \hoveredColumnId\ e \setHoveredColumnId\ não existiam no hook, mas eram chamados em \SuperGrid.tsx\

### Bug 2 — \cancelCellEdit\ / \startCellEdit\ undefined (runtime)
- **Arquivo:** \useGridState.ts\
- **Causa:** As funções de edição inline de célula não eram retornadas pelo hook

### Bug 3 — Tipos ausentes em \SuperGridConfig\
- **Arquivo:** \SuperGrid.types.ts\
- **Causa:** \locale\, \highlight\ e \reezePanes\ eram usados em \SuperGrid.tsx\ mas não estavam na interface

### Bug 4 — \getDevUsers\ com Prisma include inválido
- **Arquivo:** \src/app/auth/actions.ts\
- **Causa:** \include: { Tenant: true }\ — \User\ não possui relação direta \Tenant\ (usa \UsersOnTenants\); campos \u.name\ e \u.role\ não existem no model

## Solução

### \useGridState.ts\
- Adicionado \hoveredColumnId\ (useState) + \setHoveredColumnId\
- Adicionado \editingCellId\, \editingCellValue\, \startCellEdit()\, \cancelCellEdit()\

### \SuperGrid.types.ts\
- Adicionado \locale?: GridLocale\
- Adicionado \highlight?: { activeRow?, stripedRows?, columnHover?, rules? }\
- Adicionado \reezePanes?: { enabled?, showDividerShadow? }\

### \uth/actions.ts\
- \include: { Tenant: true }\ → \{ UsersOnRoles: { include: { Role: true } }, UsersOnTenants: { include: { Tenant: true } } }\
- \u.name\ → \u.fullName\
- \u.role\ → \u.UsersOnRoles?.[0]?.Role?.name\
- \u.tenantId\ → \u.UsersOnTenants?.[0]?.tenantId\

## Validação
- ✅ \
pm run typecheck\ sem erros nos arquivos alterados
- ✅ 0 erros TypeScript em todos os 3 arquivos