### PR TITLE
feat: adicionar CTA 'Ir para pregão online' com regras de elegibilidade

### DIFF
--- a/context/REGRAS_NEGOCIO_CONSOLIDADO.md
+++ b/context/REGRAS_NEGOCIO_CONSOLIDADO.md
@@ -104,6 +104,27 @@ Controller (Server Action) → Service → Repository → ZOD → Prisma ORM →
 - **Quando** o usuário abre a página de edição
 - **Então** o mapa mostra o marcador imediatamente e aplica `flyTo` no ponto, sem depender da busca de CEP
 
+### RN-017: CTA "Ir para pregão online"
+✅ O CTA de pregão online deve apontar para `/auctions/{auctionId}/live`.
+✅ O CTA só deve aparecer quando o leilão estiver na janela ativa de pregão:
+- status `ABERTO_PARA_LANCES`;
+- data atual maior/igual à abertura efetiva (`actualOpenDate` ou `openDate` ou `auctionDate`);
+- data atual menor/igual a `endDate`.
+✅ O CTA só pode ser exibido para usuário autenticado e habilitado no leilão.
+✅ O CTA deve exibir ícone de online, tooltip explicativa e badge `Online` com animação de piscar lento.
+✅ A cobertura é obrigatória em cards/list items, detalhes e modais de leilão/lote, incluindo listagens administrativas.
+
+**Cenário BDD - Exibição do CTA dentro da janela**
+- **Dado** um usuário autenticado e habilitado
+- **E** um leilão com status `ABERTO_PARA_LANCES` dentro da janela temporal
+- **Quando** a interface renderiza card/lista/detalhe/modal de leilão/lote
+- **Então** o CTA "Ir para pregão online" é exibido
+
+**Cenário BDD - Ocultação do CTA fora das regras**
+- **Dado** um usuário não autenticado ou não habilitado, ou leilão fora da janela
+- **Quando** a interface renderiza card/lista/detalhe/modal de leilão/lote
+- **Então** o CTA "Ir para pregão online" não é exibido
+
 ### RN-005: Herança de Mídia
 ✅ Lote pode herdar galeria de `Asset` vinculado  
 ✅ Leilão pode herdar imagem de Lote vinculado  

--- a/openspec/changes/add-go-to-live-auction-cta/proposal.md
+++ b/openspec/changes/add-go-to-live-auction-cta/proposal.md
@@ -1,0 +1,15 @@
+# Change: Add CTA "Ir para pregão online"
+
+## Why
+Usuários precisam acessar rapidamente o pregão ao vivo durante a janela ativa do leilão, com regras claras de elegibilidade e consistência em todas as superfícies (cards, listas, detalhes, modais e admin).
+
+## What Changes
+- Adiciona CTA reutilizável "Ir para pregão online" com ícone de status online, tooltip e badge piscando lentamente.
+- Aplica regra temporal unificada da janela de pregão (status aberto + dentro do intervalo de datas).
+- Restringe exibição para usuário logado e habilitado no leilão.
+- Integra CTA em cards/list items, detalhes e modais de leilão/lote, incluindo listagens administrativas.
+- Adiciona testes unitários da regra temporal e teste E2E de visibilidade para usuário não autenticado.
+
+## Impact
+- Affected specs: online-auction-live-cta
+- Affected code: `src/lib/ui-helpers.ts`, `src/components/auction/*`, `src/components/cards/*`, `src/app/auctions/*`, `src/components/admin/auction-preparation/tabs/*`, `tests/unit/ui-helpers.test.ts`, `tests/e2e/*`

--- a/openspec/changes/add-go-to-live-auction-cta/specs/online-auction-live-cta/spec.md
+++ b/openspec/changes/add-go-to-live-auction-cta/specs/online-auction-live-cta/spec.md
@@ -1,0 +1,42 @@
+## ADDED Requirements
+
+### Requirement: Exibição condicional do CTA de pregão online
+O sistema SHALL exibir o botão "Ir para pregão online" apenas quando o leilão estiver na janela ativa de pregão e o usuário estiver autenticado e habilitado para o leilão.
+
+#### Scenario: Usuário autenticado e habilitado durante janela ativa
+- **GIVEN** um leilão com status `ABERTO_PARA_LANCES`
+- **AND** a data atual está entre a abertura efetiva e o encerramento do leilão
+- **AND** o usuário está autenticado e habilitado para o leilão
+- **WHEN** a interface renderiza um card, lista, detalhe ou modal de leilão/lote
+- **THEN** o CTA "Ir para pregão online" deve ser exibido
+- **AND** deve navegar para `/auctions/{auctionId}/live`
+
+#### Scenario: Usuário não autenticado
+- **GIVEN** um leilão com status `ABERTO_PARA_LANCES` na janela ativa
+- **AND** o usuário não está autenticado
+- **WHEN** a interface renderiza um card, lista, detalhe ou modal de leilão/lote
+- **THEN** o CTA "Ir para pregão online" não deve ser exibido
+
+#### Scenario: Leilão fora da janela de pregão
+- **GIVEN** um usuário autenticado e habilitado
+- **AND** o leilão está fora da janela ativa (antes da abertura ou após o encerramento)
+- **WHEN** a interface renderiza um card, lista, detalhe ou modal de leilão/lote
+- **THEN** o CTA "Ir para pregão online" não deve ser exibido
+
+### Requirement: Indicadores visuais do CTA
+O sistema SHALL apresentar indicadores visuais de pregão ao vivo no CTA para reforçar contexto em tempo real.
+
+#### Scenario: Renderização do CTA
+- **GIVEN** o CTA é exibido
+- **WHEN** o usuário visualiza o botão
+- **THEN** o botão deve incluir ícone sugestivo de online
+- **AND** deve incluir tooltip explicativa
+- **AND** deve incluir badge "Online" com animação de piscar lento
+
+### Requirement: Cobertura transversal de UI
+O sistema SHALL disponibilizar o CTA em superfícies públicas e administrativas relacionadas a leilões e lotes.
+
+#### Scenario: Locais obrigatórios de exibição
+- **GIVEN** as condições de exibição são atendidas
+- **WHEN** o usuário acessa cards/list items, detalhes, modais e listagens administrativas
+- **THEN** o CTA deve estar disponível nesses contextos

--- a/openspec/changes/add-go-to-live-auction-cta/tasks.md
+++ b/openspec/changes/add-go-to-live-auction-cta/tasks.md
@@ -1,0 +1,14 @@
+## 1. Implementação
+- [x] 1.1 Criar helper unificado de janela temporal do pregão online
+- [x] 1.2 Criar componente reutilizável de CTA para rota `/auctions/{id}/live`
+- [x] 1.3 Integrar CTA em cards e list items de leilão/lote
+- [x] 1.4 Integrar CTA em páginas e modais de detalhe de leilão/lote
+- [x] 1.5 Integrar CTA em listagens administrativas
+
+## 2. Qualidade
+- [x] 2.1 Adicionar testes unitários da regra temporal
+- [x] 2.2 Adicionar teste E2E Playwright para regra de visibilidade sem login
+- [x] 2.3 Executar typecheck e testes focados
+
+## 3. Documentação
+- [x] 3.1 Atualizar regras oficiais com a nova regra de CTA de pregão online

--- a/src/app/auctions/[auctionId]/auction-details-client-v2.tsx
+++ b/src/app/auctions/[auctionId]/auction-details-client-v2.tsx
@@ -36,6 +36,7 @@ import HeroSection from './components/hero-section';
 import AuctionStatsCard from './components/auction-stats-card';
 import BidExpertAuctionStagesTimeline from '@/components/auction/BidExpertAuctionStagesTimeline';
 import { useFloatingActions } from '@/components/floating-actions/floating-actions-provider';
+import GoToLiveAuctionButton from '@/components/auction/go-to-live-auction-button';
 
 const SidebarFilter = dynamic(() => import('@/components/BidExpertFilter'), {
   loading: () => <SidebarFiltersSkeleton />,
@@ -360,6 +361,14 @@ export default function AuctionDetailsClientV2({
                     </CardContent>
                   </Card>
                 )}
+
+                <GoToLiveAuctionButton
+                  auction={auction}
+                  className="w-full"
+                  variant="default"
+                  label="Ir para pregão online"
+                  dataAiId="auction-details-v2-go-live-btn"
+                />
               </aside>
             </div>
           </TabsContent>

--- a/src/app/auctions/[auctionId]/auction-details-client.tsx
+++ b/src/app/auctions/[auctionId]/auction-details-client.tsx
@@ -36,6 +36,7 @@ import { Tooltip, TooltipProvider, TooltipTrigger, TooltipContent } from '@/comp
 import BidExpertCard from '@/components/BidExpertCard';
 import BidExpertListItem from '@/components/BidExpertListItem';
 import { useFloatingActions } from '@/components/floating-actions/floating-actions-provider';
+import GoToLiveAuctionButton from '@/components/auction/go-to-live-auction-button';
 
 
 const SidebarFilter = dynamic(() => import('@/components/BidExpertFilter'), {
@@ -287,6 +288,7 @@ export default function AuctionDetailsClient({ auction, auctioneer, platformSett
                   </div>
 
                   <div className="mt-auto pt-6 flex flex-wrap gap-2">
+                      <GoToLiveAuctionButton auction={auction} dataAiId="auction-details-go-live-btn" />
                       <Button variant="outline">
                           <Heart className="h-4 w-4 mr-2" /> Favoritar Leilão
                       </Button>

--- a/src/app/auctions/[auctionId]/lots/[lotId]/lot-detail-client.tsx
+++ b/src/app/auctions/[auctionId]/lots/[lotId]/lot-detail-client.tsx
@@ -74,6 +74,7 @@ import BidExpertCard from '@/components/BidExpertCard';
 import { InvestorAnalysisSection } from '@/components/lots';
 import { ptBR } from 'date-fns/locale';
 import StickyBidBar from '@/components/auction/sticky-bid-bar';
+import GoToLiveAuctionButton from '@/components/auction/go-to-live-auction-button';
 
 
 const LotMapDisplay = dynamic(() => import('@/components/auction/lot-map-display'), {
@@ -877,6 +878,12 @@ export default function LotDetailClientContent({
                 </Card>
               </div>
               <div className="lg:col-span-1 space-y-6 lg:sticky lg:top-24 self-start hidden lg:block">
+                  <GoToLiveAuctionButton
+                    auction={auction}
+                    className="w-full"
+                    variant="default"
+                    dataAiId="lot-detail-go-live-btn"
+                  />
                   <BiddingPanel 
                     currentLot={lot} 
                     auction={auction} 

--- a/src/components/admin/auction-preparation/tabs/dashboard-tab.tsx
+++ b/src/components/admin/auction-preparation/tabs/dashboard-tab.tsx
@@ -21,6 +21,7 @@ import type {
   AuctionPreparationHabilitation,
   AuctionPreparationWin,
 } from '@/types';
+import GoToLiveAuctionButton from '@/components/auction/go-to-live-auction-button';
 
 const currencyFormatter = new Intl.NumberFormat('pt-BR', {
   style: 'currency',
@@ -171,6 +172,9 @@ export function DashboardTab({ auction, bids, habilitations, userWins }: Dashboa
           <CardDescription>Acesso rápido às principais funcionalidades</CardDescription>
         </CardHeader>
         <CardContent>
+          <div className="mb-3">
+            <GoToLiveAuctionButton auction={auction} variant="default" className="w-full md:w-auto" dataAiId="admin-dashboard-go-live-btn" />
+          </div>
           <div className="grid gap-3 md:grid-cols-2 lg:grid-cols-4">
             {quickActions.map((action) => (
               <Link key={action.label} href={action.href}>

--- a/src/components/admin/auction-preparation/tabs/lots-tab.tsx
+++ b/src/components/admin/auction-preparation/tabs/lots-tab.tsx
@@ -17,6 +17,7 @@ import { Search, Edit, Eye, TrendingUp, AlertTriangle } from 'lucide-react';
 import Link from 'next/link';
 import { useMemo, useState } from 'react';
 import type { AuctionPreparationBid } from '@/types';
+import GoToLiveAuctionButton from '@/components/auction/go-to-live-auction-button';
 
 const currencyFormatter = new Intl.NumberFormat('pt-BR', {
   style: 'currency',
@@ -193,6 +194,7 @@ export function LotsTab({ auction, bids }: LotsTabProps) {
                         )}
                       </TableCell>
                       <TableCell className="text-right space-x-2">
+                        <GoToLiveAuctionButton auction={auction} dataAiId="admin-lots-go-live-btn" />
                         <Link href={`/admin/lots/${lot.id}`}>
                           <Button variant="ghost" size="sm">
                             <Eye className="h-4 w-4" />

--- a/src/components/auction-preview-modal-v2.tsx
+++ b/src/components/auction-preview-modal-v2.tsx
@@ -12,6 +12,7 @@ import { useMemo, useState } from 'react';
 import { Avatar, AvatarFallback, AvatarImage } from './ui/avatar';
 import { Card, CardHeader, CardTitle, CardContent } from '@/components/ui/card';
 import { isValidImageUrl } from '@/lib/ui-helpers';
+import GoToLiveAuctionButton from '@/components/auction/go-to-live-auction-button';
 
 interface AuctionPreviewModalProps {
   auction: Auction;
@@ -132,11 +133,14 @@ export default function AuctionPreviewModal({ auction, isOpen, onClose }: Auctio
         
         <DialogFooter className="p-4 sm:p-6 border-t bg-background flex justify-between w-full flex-shrink-0">
             <Button variant="outline" onClick={onClose}> Fechar </Button>
+          <div className="flex items-center gap-2">
+            <GoToLiveAuctionButton auction={auction} dataAiId="auction-preview-go-live-btn" />
             <Button asChild>
-                <Link href={`/auctions/${auction.publicId || auction.id}`}>
-                    <Eye className="mr-2 h-4 w-4" /> Ver Leilão Completo
-                </Link>
+              <Link href={`/auctions/${auction.publicId || auction.id}`}>
+                <Eye className="mr-2 h-4 w-4" /> Ver Leilão Completo
+              </Link>
             </Button>
+          </div>
         </DialogFooter>
       </DialogContent>
     </Dialog>

--- a/src/components/auction/go-to-live-auction-button.tsx
+++ b/src/components/auction/go-to-live-auction-button.tsx
@@ -1,0 +1,102 @@
+/**
+ * @fileoverview Botão reutilizável para acesso ao pregão online.
+ * Exibe CTA apenas para usuário autenticado e habilitado, dentro da janela temporal do leilão.
+ */
+'use client';
+
+import { useEffect, useMemo, useState } from 'react';
+import Link from 'next/link';
+import { Wifi } from 'lucide-react';
+import type { Auction } from '@/types';
+import { Button } from '@/components/ui/button';
+import { Badge } from '@/components/ui/badge';
+import { Tooltip, TooltipContent, TooltipProvider, TooltipTrigger } from '@/components/ui/tooltip';
+import { useAuth } from '@/contexts/auth-context';
+import { checkHabilitationForAuctionAction } from '@/app/admin/habilitations/actions';
+import { cn } from '@/lib/utils';
+import { isAuctionInPregaoWindow } from '@/lib/ui-helpers';
+
+interface GoToLiveAuctionButtonProps {
+  auction: Pick<Auction, 'id' | 'publicId' | 'status' | 'openDate' | 'actualOpenDate' | 'endDate' | 'auctionDate'>;
+  className?: string;
+  size?: 'sm' | 'default' | 'lg' | 'icon';
+  variant?: 'default' | 'secondary' | 'outline' | 'ghost' | 'link' | 'destructive' | 'mapGhost';
+  requireHabilitation?: boolean;
+  label?: string;
+  dataAiId?: string;
+}
+
+export default function GoToLiveAuctionButton({
+  auction,
+  className,
+  size = 'sm',
+  variant = 'outline',
+  requireHabilitation = true,
+  label = 'Ir para pregão online',
+  dataAiId = 'go-live-auction-btn',
+}: GoToLiveAuctionButtonProps) {
+  const { userProfileWithPermissions } = useAuth();
+  const [isHabilitated, setIsHabilitated] = useState(false);
+  const [isChecking, setIsChecking] = useState(false);
+
+  const isInLiveWindow = useMemo(() => isAuctionInPregaoWindow(auction), [auction]);
+
+  useEffect(() => {
+    if (!isInLiveWindow || !userProfileWithPermissions?.id) {
+      setIsHabilitated(false);
+      return;
+    }
+
+    if (!requireHabilitation) {
+      setIsHabilitated(true);
+      return;
+    }
+
+    let mounted = true;
+    setIsChecking(true);
+
+    checkHabilitationForAuctionAction(userProfileWithPermissions.id, auction.id)
+      .then((result) => {
+        if (mounted) {
+          setIsHabilitated(result);
+        }
+      })
+      .catch(() => {
+        if (mounted) {
+          setIsHabilitated(false);
+        }
+      })
+      .finally(() => {
+        if (mounted) {
+          setIsChecking(false);
+        }
+      });
+
+    return () => {
+      mounted = false;
+    };
+  }, [auction.id, isInLiveWindow, requireHabilitation, userProfileWithPermissions?.id]);
+
+  if (!isInLiveWindow || !userProfileWithPermissions?.id || isChecking || !isHabilitated) {
+    return null;
+  }
+
+  return (
+    <TooltipProvider>
+      <Tooltip>
+        <TooltipTrigger asChild>
+          <Button asChild size={size} variant={variant} className={cn('gap-2', className)} data-ai-id={dataAiId}>
+            <Link href={`/auctions/${auction.publicId || auction.id}/live`} data-ai-id={`${dataAiId}-link`}>
+              <Wifi className="h-4 w-4" />
+              <span>{label}</span>
+              <Badge className="animate-pulse [animation-duration:2.5s]">Online</Badge>
+            </Link>
+          </Button>
+        </TooltipTrigger>
+        <TooltipContent>
+          <p>Entrar no pregão ao vivo deste leilão</p>
+        </TooltipContent>
+      </Tooltip>
+    </TooltipProvider>
+  );
+}

--- a/src/components/cards/auction-card.tsx
+++ b/src/components/cards/auction-card.tsx
@@ -18,6 +18,7 @@ import { Tooltip, TooltipContent, TooltipProvider, TooltipTrigger } from '@/comp
 import EntityEditMenu from '../entity-edit-menu';
 import BidExpertAuctionStagesTimeline from '@/components/auction/BidExpertAuctionStagesTimeline';
 import ConsignorLogoBadge from '../consignor-logo-badge';
+import GoToLiveAuctionButton from '@/components/auction/go-to-live-auction-button';
 
 
 interface AuctionCardProps {
@@ -227,9 +228,12 @@ export default function AuctionCard({ auction, onUpdate }: AuctionCardProps) {
                 </p>
               </div>
             )}
-            <Button asChild size="sm" className="btn-card-view-lots" data-ai-id="auction-card-view-lots-btn">
-              <Link href={`/auctions/${auction.publicId || auction.id}`}>Ver Lotes ({auction.totalLots || 0})</Link>
-            </Button>
+            <div className="flex flex-col gap-2 items-end">
+              <GoToLiveAuctionButton auction={auction} dataAiId="auction-card-go-live-btn" />
+              <Button asChild size="sm" className="btn-card-view-lots" data-ai-id="auction-card-view-lots-btn">
+                <Link href={`/auctions/${auction.publicId || auction.id}`}>Ver Lotes ({auction.totalLots || 0})</Link>
+              </Button>
+            </div>
           </CardFooter>
         </Card>
         {isPreviewModalOpen && (

--- a/src/components/cards/auction-list-item.tsx
+++ b/src/components/cards/auction-list-item.tsx
@@ -16,6 +16,7 @@ import BidExpertAuctionStagesTimeline from '@/components/auction/BidExpertAuctio
 import EntityEditMenu from '../entity-edit-menu';
 import ConsignorLogoBadge from '../consignor-logo-badge';
 import { cn } from '@/lib/utils';
+import GoToLiveAuctionButton from '@/components/auction/go-to-live-auction-button';
 
 
 interface AuctionListItemProps {
@@ -205,16 +206,19 @@ export default function AuctionListItem({ auction, onUpdate, density = 'default'
                   R$ {(auction.initialOffer || 0).toLocaleString('pt-BR', { minimumFractionDigits: 2, maximumFractionDigits: 2 })}
                 </p>
               </div>
-              <Button
-                asChild
-                size="sm"
-                variant={isCompact ? 'mapGhost' : 'default'}
-                className="w-full md:w-auto mt-2 md:mt-0"
-              >
-                <Link href={`/auctions/${auction.publicId || auction.id}`}>
-                    <Eye className="mr-2 h-4 w-4" /> Ver Leilão ({auction.totalLots})
-                </Link>
-              </Button>
+              <div className="w-full md:w-auto mt-2 md:mt-0 flex flex-col gap-2">
+                <GoToLiveAuctionButton auction={auction} className="w-full" dataAiId="auction-list-go-live-btn" />
+                <Button
+                  asChild
+                  size="sm"
+                  variant={isCompact ? 'mapGhost' : 'default'}
+                  className="w-full md:w-auto"
+                >
+                  <Link href={`/auctions/${auction.publicId || auction.id}`}>
+                      <Eye className="mr-2 h-4 w-4" /> Ver Leilão ({auction.totalLots})
+                  </Link>
+                </Button>
+              </div>
             </div>
           </div>
         </div>

--- a/src/components/cards/lot-card.tsx
+++ b/src/components/cards/lot-card.tsx
@@ -26,6 +26,7 @@ import LotCountdown from '../lot-countdown';
 import BidExpertAuctionStagesTimeline from '@/components/auction/BidExpertAuctionStagesTimeline';
 import ConsignorLogoBadge from '../consignor-logo-badge';
 import { useCurrency } from '@/contexts/currency-context';
+import GoToLiveAuctionButton from '@/components/auction/go-to-live-auction-button';
 
 
 interface LotCardProps {
@@ -351,11 +352,14 @@ function LotCardClientContent({ lot, auction, badgeVisibilityConfig, platformSet
         </CardContent>
 
         <CardFooter className="footer-card-lot" data-ai-id="lot-card-footer">
-          <Button asChild className="btn-card-bid-action" data-ai-id="lot-card-bid-btn">
-            <Link href={lotDetailUrl}>
-              <Gavel className="icon-btn-bid" /> Fazer Lance
-            </Link>
-          </Button>
+          <div className="flex w-full flex-col gap-2">
+            {auction && <GoToLiveAuctionButton auction={auction} className="w-full" dataAiId="lot-card-go-live-btn" />}
+            <Button asChild className="btn-card-bid-action" data-ai-id="lot-card-bid-btn">
+              <Link href={lotDetailUrl}>
+                <Gavel className="icon-btn-bid" /> Fazer Lance
+              </Link>
+            </Button>
+          </div>
         </CardFooter>
       </Card>
       {isPreviewModalOpen && (

--- a/src/components/cards/lot-list-item.tsx
+++ b/src/components/cards/lot-list-item.tsx
@@ -16,6 +16,7 @@ import BidExpertAuctionStagesTimeline from '@/components/auction/BidExpertAuctio
 import EntityEditMenu from '../entity-edit-menu';
 import ConsignorLogoBadge from '../consignor-logo-badge';
 import { cn } from '@/lib/utils';
+import GoToLiveAuctionButton from '@/components/auction/go-to-live-auction-button';
 
 interface LotListItemProps {
   lot: Lot;
@@ -195,16 +196,19 @@ export default function LotListItem({ lot, auction, platformSettings, onUpdate, 
                   R$ {getLotDisplayPrice(lot, auction).value.toLocaleString('pt-BR', { minimumFractionDigits: 2, maximumFractionDigits: 2 })}
                 </p>
               </div>
-              <Button
-                asChild
-                size="sm"
-                variant={isCompact ? 'mapGhost' : 'default'}
-                className="w-full md:w-auto mt-2 md:mt-0"
-              >
-                <Link href={`/auctions/${lot.auctionId}/lots/${lot.publicId || lot.id}`}>
-                  <Eye className="mr-2 h-4 w-4" /> Ver Lote
-                </Link>
-              </Button>
+              <div className="w-full md:w-auto mt-2 md:mt-0 flex flex-col gap-2">
+                {auction && <GoToLiveAuctionButton auction={auction} className="w-full" dataAiId="lot-list-go-live-btn" />}
+                <Button
+                  asChild
+                  size="sm"
+                  variant={isCompact ? 'mapGhost' : 'default'}
+                  className="w-full md:w-auto"
+                >
+                  <Link href={`/auctions/${lot.auctionId}/lots/${lot.publicId || lot.id}`}>
+                    <Eye className="mr-2 h-4 w-4" /> Ver Lote
+                  </Link>
+                </Button>
+              </div>
             </div>
           </div>
         </div>

--- a/src/components/lot-preview-modal-v2.tsx
+++ b/src/components/lot-preview-modal-v2.tsx
@@ -44,6 +44,7 @@ import LotCountdown from './lot-countdown';
 import { useToast } from '@/hooks/use-toast';
 import { isLotFavoriteInStorage, addFavoriteLotIdToStorage, removeFavoriteLotIdFromStorage } from '@/lib/favorite-store';
 import { useCurrency } from '@/contexts/currency-context';
+import GoToLiveAuctionButton from '@/components/auction/go-to-live-auction-button';
 
 interface LotPreviewModalV2Props {
   lot: Lot | null;
@@ -488,6 +489,15 @@ export default function LotPreviewModalV2({ lot, auction, platformSettings, isOp
 
               {/* CTA Principal */}
               <div className="space-y-2 md:space-y-3 sticky bottom-0 bg-background pt-3 md:pt-4 pb-2">
+                {auction && (
+                  <GoToLiveAuctionButton
+                    auction={auction}
+                    className="w-full"
+                    size="lg"
+                    label="Ir para pregão online"
+                    dataAiId="lot-preview-go-live-btn"
+                  />
+                )}
                 <Button 
                   asChild 
                   size="lg" 

--- a/src/lib/ui-helpers.ts
+++ b/src/lib/ui-helpers.ts
@@ -415,3 +415,35 @@ export const getLotDisplayPrice = (lot: Lot, auction?: Auction): { value: number
     label: 'Lance Inicial'
   };
 };
+
+export interface AuctionPregaoWindowInput {
+  status?: string;
+  openDate?: Date | string | null;
+  actualOpenDate?: Date | string | null;
+  auctionDate?: Date | string | null;
+  endDate?: Date | string | null;
+}
+
+const parseOptionalDate = (date: Date | string | null | undefined): Date | null => {
+  if (!date) return null;
+  const parsed = new Date(date);
+  return Number.isNaN(parsed.getTime()) ? null : parsed;
+};
+
+export const isAuctionInPregaoWindow = (auction: AuctionPregaoWindowInput, referenceDate = new Date()): boolean => {
+  if (!auction || auction.status !== 'ABERTO_PARA_LANCES') {
+    return false;
+  }
+
+  const endDate = parseOptionalDate(auction.endDate);
+  if (!endDate || referenceDate > endDate) {
+    return false;
+  }
+
+  const startDate = parseOptionalDate(auction.actualOpenDate) || parseOptionalDate(auction.openDate) || parseOptionalDate(auction.auctionDate);
+  if (startDate && referenceDate < startDate) {
+    return false;
+  }
+
+  return true;
+};

--- a/tests/e2e/go-live-cta-visibility.spec.ts
+++ b/tests/e2e/go-live-cta-visibility.spec.ts
@@ -1,0 +1,19 @@
+/**
+ * @fileoverview Valida visibilidade do CTA de pregão online para usuário não autenticado.
+ */
+
+import { test, expect } from '@playwright/test';
+
+const BASE_URL = process.env.BASE_URL || 'http://demo.localhost:9005';
+
+test.describe('CTA Ir para pregão online', () => {
+  test.use({ storageState: { cookies: [], origins: [] } });
+
+  test('não exibe CTA para visitante sem login', async ({ page }) => {
+    await page.goto(`${BASE_URL}/search`, { waitUntil: 'networkidle' });
+    await page.waitForTimeout(1500);
+
+    const goLiveButtons = page.locator('[data-ai-id*="go-live"]');
+    await expect(goLiveButtons).toHaveCount(0);
+  });
+});


### PR DESCRIPTION
## Resumo\nImplementa o CTA reutilizável **Ir para pregão online** com regra temporal e de habilitação/autenticação, cobrindo superfícies públicas e administrativas.\n\n## O que foi feito\n- adiciona componente reutilizável GoToLiveAuctionButton\n- adiciona helper isAuctionInPregaoWindow em ui-helpers\n- integra CTA em cards/list items/modais/detalhes de leilão e lote\n- integra CTA em abas administrativas (dashboard e lots)\n- adiciona testes: unitário da regra temporal e E2E de visibilidade sem login\n- adiciona change OpenSpec (dd-go-to-live-auction-cta) e atualização em regras consolidadas\n\n## Validações\n- openspec validate add-go-to-live-auction-cta --strict\n- 
pm run typecheck\n- 
px vitest run tests/unit/ui-helpers.test.ts\n- 
px playwright test tests/e2e/go-live-cta-visibility.spec.ts --project=chromium\n\n## Observações\n- Mudanças paralelas não relacionadas permaneceram fora deste commit/PR.