### PR TITLE
fix(header): seletor de moeda exibindo 3 moedas e z-index corrigido

### DIFF
--- a/src/components/layout/header.tsx
+++ b/src/components/layout/header.tsx
@@ -590,9 +590,8 @@ export default function Header({
                   </span>
                 </Button>
               </DropdownMenuTrigger>
-              <DropdownMenuContent align="end" className="w-48" data-ai-id="header-currency-menu">
+              <DropdownMenuContent align="end" className="w-48 z-[2000]" data-ai-id="header-currency-menu">
                 {currencyOptions
-                  .filter((option) => option.code !== currency)
                   .map((option) => (
                   <DropdownMenuItem
                     key={option.code}


### PR DESCRIPTION
## Correções no Seletor de Moeda do Header

### Problemas
1. Dropdown mostrava apenas 2 moedas - o .filter() removia a moeda selecionada
2. Dropdown abria atrás do header - z-index do portal (50) era menor que o header (1600)

### Soluções
- Removido .filter() para exibir BRL, USD e EUR sempre
- Adicionado z-[2000] no DropdownMenuContent

### Arquivo alterado
- src/components/layout/header.tsx