### PR TITLE
feat(contact): add phone/WhatsApp field to contact form

### DIFF
--- a/prisma/schema.postgresql.prisma
+++ b/prisma/schema.postgresql.prisma
@@ -444,6 +444,7 @@ model ContactMessage {
   id        BigInt   @id @default(autoincrement())
   name      String
   email     String
+  phone     String?  @db.VarChar(30)
   subject   String?
   message   String   @db.Text
   isRead    Boolean  @default(false)

--- a/prisma/schema.prisma
+++ b/prisma/schema.prisma
@@ -446,6 +446,7 @@ model ContactMessage {
   id        BigInt   @id @default(autoincrement())
   name      String
   email     String
+  phone     String?  @db.VarChar(30)
   subject   String?
   message   String   @db.Text
   isRead    Boolean  @default(false)

--- a/src/app/contact/actions.ts
+++ b/src/app/contact/actions.ts
@@ -20,6 +20,7 @@ const contactMessageService = new ContactMessageService();
 export async function saveContactMessage(formData: FormData): Promise<{ success: boolean; message: string }> {
   const name = formData.get('name') as string;
   const email = formData.get('email') as string;
+  const phone = (formData.get('phone') as string) || undefined;
   const subject = formData.get('subject') as string;
   const message = formData.get('message') as string;
 
@@ -27,7 +28,7 @@ export async function saveContactMessage(formData: FormData): Promise<{ success:
     return { success: false, message: 'Todos os campos são obrigatórios.' };
   }
 
-  const result = await contactMessageService.saveMessage({ name, email, subject, message });
+  const result = await contactMessageService.saveMessage({ name, email, phone, subject, message });
 
   if (result.success) {
     // Revalida o cache da página de administração de mensagens para que a nova mensagem apareça imediatamente.

--- a/src/app/contact/page.tsx
+++ b/src/app/contact/page.tsx
@@ -69,20 +69,26 @@ export default function ContactPage() {
                 <div className="grid grid-cols-1 sm:grid-cols-2 gap-4">
                   <div className="space-y-2">
                     <Label htmlFor="name">Nome Completo</Label>
-                    <Input id="name" name="name" placeholder="Seu nome completo" required disabled={isLoading} />
+                    <Input id="name" name="name" placeholder="Seu nome completo" required disabled={isLoading} data-ai-id="contact-input-name" />
                   </div>
                   <div className="space-y-2">
                     <Label htmlFor="email">Endereço de Email</Label>
-                    <Input id="email" name="email" type="email" placeholder="seu@email.com" required disabled={isLoading} />
+                    <Input id="email" name="email" type="email" placeholder="seu@email.com" required disabled={isLoading} data-ai-id="contact-input-email" />
+                  </div>
+                </div>
+                <div className="grid grid-cols-1 sm:grid-cols-2 gap-4">
+                  <div className="space-y-2">
+                    <Label htmlFor="phone">Telefone / WhatsApp <span className="text-muted-foreground text-xs">(opcional)</span></Label>
+                    <Input id="phone" name="phone" type="tel" placeholder="(11) 9 9999-9999" disabled={isLoading} data-ai-id="contact-input-phone" />
+                  </div>
+                  <div className="space-y-2">
+                    <Label htmlFor="subject">Assunto</Label>
+                    <Input id="subject" name="subject" placeholder="Referente ao leilão..." required disabled={isLoading} data-ai-id="contact-input-subject" />
                   </div>
                 </div>
                 <div className="space-y-2">
-                  <Label htmlFor="subject">Assunto</Label>
-                  <Input id="subject" name="subject" placeholder="Referente ao leilão..." required disabled={isLoading} />
-                </div>
-                <div className="space-y-2">
                   <Label htmlFor="message">Mensagem</Label>
-                  <Textarea id="message" name="message" placeholder="Sua mensagem aqui..." rows={5} required disabled={isLoading} />
+                  <Textarea id="message" name="message" placeholder="Sua mensagem aqui..." rows={5} required disabled={isLoading} data-ai-id="contact-input-message" />
                 </div>
                 <Button type="submit" className="w-full sm:w-auto" disabled={isLoading}>
                   {isLoading && <Loader2 className="mr-2 h-4 w-4 animate-spin" />}

--- a/src/services/contact-message.service.ts
+++ b/src/services/contact-message.service.ts
@@ -61,7 +61,7 @@ export class ContactMessageService {
       if (adminWhatsApp) {
         this.whatsAppService.sendNotification({
           to: adminWhatsApp.startsWith('whatsapp:') ? adminWhatsApp : `whatsapp:${adminWhatsApp}`,
-          message: `📬 Nova mensagem de contato\n*De:* ${data.name} <${data.email}>\n*Assunto:* ${data.subject}\n*Prévia:* ${String(data.message).slice(0, 100)}...`,
+          message: `📬 Nova mensagem de contato\n*De:* ${data.name} <${data.email}>${data.phone ? `\n*Telefone/WhatsApp:* ${data.phone}` : ''}\n*Assunto:* ${data.subject}\n*Prévia:* ${String(data.message).slice(0, 100)}...`,
         }).catch((err: Error) => console.warn('[ContactMessageService] Falha ao notificar WhatsApp:', err.message));
       } else {
         console.info(`[ContactMessageService] ADMIN_WHATSAPP_NUMBER não configurado — WhatsApp ignorado. Assunto: ${data.subject}`);


### PR DESCRIPTION
## Resumo

Adiciona campo de **Telefone / WhatsApp** (opcional) ao formulário de contato em \/contact\.

## Mudanças

- **Schema** (\schema.prisma\ + \schema.postgresql.prisma\): coluna \phone VARCHAR(30) nullable\ em \ContactMessage\
- **Formulário** (\/contact\): campo phone entre email e assunto, com label 'Telefone / WhatsApp (opcional)'
- **Action** (\ctions.ts\): captura \phone\ do FormData e passa ao service
- **Service** (\contact-message.service.ts\): inclui telefone na mensagem WhatsApp ao admin
- **Banco (Vercel/Neon)**: \ALTER TABLE ContactMessage ADD COLUMN IF NOT EXISTS phone VARCHAR(30)\ — já aplicado

## Teste manual

1. Acesse \/contact\
2. Preencha o formulário (telefone é opcional)
3. Envie — o painel \/admin/contact-messages\ deve mostrar a mensagem