### PR TITLE
fix(csp): add nominatim.openstreetmap.org to connect-src for map geocoding

### DIFF
--- a/next.config.mjs
+++ b/next.config.mjs
@@ -26,7 +26,7 @@ const securityHeaders = [
       "script-src 'self' 'unsafe-eval' 'unsafe-inline' https://*.googleapis.com https://*.gstatic.com https://maps.googleapis.com https://*.vercel-analytics.com https://cdn.vercel-insights.com https://va.vercel-scripts.com",
       "style-src 'self' 'unsafe-inline' https://fonts.googleapis.com",
       "img-src 'self' data: blob: https://placehold.co https://images.unsplash.com https://picsum.photos https://fastly.picsum.photos https://firebasestorage.googleapis.com https://*.s3.amazonaws.com https://res.cloudinary.com https://*.googleusercontent.com https://maps.googleapis.com https://maps.gstatic.com https://*.tile.openstreetmap.org https://unpkg.com https://blob.vercel-storage.com https://*.blob.vercel-storage.com https://*.public.blob.vercel-storage.com",
-      "connect-src 'self' https://*.googleapis.com https://*.firebaseio.com wss://*.firebaseio.com https://*.vercel-analytics.com https://cdn.vercel-insights.com https://va.vercel-scripts.com https://maps.googleapis.com",
+      "connect-src 'self' https://*.googleapis.com https://*.firebaseio.com wss://*.firebaseio.com https://*.vercel-analytics.com https://cdn.vercel-insights.com https://va.vercel-scripts.com https://maps.googleapis.com https://nominatim.openstreetmap.org",
       "font-src 'self' https://fonts.gstatic.com",
       "frame-src 'self' https://*.firebaseapp.com https://www.google.com https://maps.google.com",
     ].join('; ')


### PR DESCRIPTION
## Problem
Map pins not appearing on Vercel because CSP connect-src blocks Nominatim geocoding API requests (145 console errors).

## Fix
Added `https://nominatim.openstreetmap.org` to `connect-src` directive in `next.config.mjs`.