### PR TITLE
fix(auction-control): correct Prisma relation name lots→AssetsOnLots in getAuctionPreparationData

### DIFF
--- a/src/app/admin/auctions/actions.ts
+++ b/src/app/admin/auctions/actions.ts
@@ -76,9 +76,9 @@ export async function getAuctionPreparationData(auctionIdentifier: string): Prom
         }
     }
 
-    assetWhere.lots = {
+    assetWhere.AssetsOnLots = {
         none: {
-            lot: {
+            Lot: {
                 auctionId: numericAuctionId,
             },
         },


### PR DESCRIPTION
## Resumo

Corrige erro **runtime** ao abrir o Painel do Leilão (Auction Control Center):

```
Invalid `prisma.asset.findMany()` invocation:
Unknown argument `lots`. Did you mean `lotId`?
```

## Causa Raiz

Em `src/app/admin/auctions/actions.ts`, a função `getAuctionPreparationData()` filtrava ativos não-loteados usando nomes de relação incorretos:

- `assetWhere.lots` → **deveria ser** `assetWhere.AssetsOnLots`
- `lot: { auctionId }` → **deveria ser** `Lot: { auctionId }`

O modelo `Asset` no schema Prisma usa `AssetsOnLots` (tabela de junção many-to-many) como nome da relação, e a relação interna usa `Lot` (com L maiúsculo).

## Alteração

| Arquivo | Linha | Antes | Depois |
|---------|-------|-------|--------|
| `src/app/admin/auctions/actions.ts` | 79 | `assetWhere.lots` | `assetWhere.AssetsOnLots` |
| `src/app/admin/auctions/actions.ts` | 81 | `lot:` | `Lot:` |

## Validação

- [x] Fix aplicado e testado localmente
- [x] `npx tsc --noEmit` — zero erros novos introduzidos
- [x] Servidor hot-reload confirmou página acessível sem crash
- [x] Branch isolada via Git Worktree (worktree removido após push)

## Impacto

- **Rota afetada:** `/admin/auctions/[auctionId]/auction-control-center`
- **Severidade:** Bloqueante — página crashava com erro Prisma para todo leilão
- **Risco:** Mínimo — alteração de 2 linhas em nomes de relação