### PR TITLE
feat(admin): rodapé fixo Dev Info com branch/server/provider

### DIFF
--- a/src/app/admin/admin-layout.client.tsx
+++ b/src/app/admin/admin-layout.client.tsx
@@ -12,6 +12,7 @@ import { WidgetPreferencesProvider } from '@/contexts/widget-preferences-context
 import WidgetConfigurationModal from '@/components/admin/dashboard/WidgetConfigurationModal';
 import { ThemeProvider } from '@/components/theme-provider';
 import AdminQueryMonitor from '@/components/support/admin-query-monitor';
+import DevInfoIndicator from '@/components/layout/dev-info-indicator';
 
 interface AdminLayoutClientProps {
   children: React.ReactNode;
@@ -31,7 +32,7 @@ const ADMIN_ACCESS_PERMISSIONS = [
 ];
 
 export function AdminLayoutClient({ children }: AdminLayoutClientProps) {
-  const { userProfileWithPermissions, loading } = useAuth();
+  const { userProfileWithPermissions, activeTenantId, loading } = useAuth();
   const router = useRouter();
   const pathname = usePathname();
   const [isCommandPaletteOpen, setCommandPaletteOpen] = useState(false);
@@ -67,6 +68,11 @@ export function AdminLayoutClient({ children }: AdminLayoutClientProps) {
   }
 
   const canAccessAdmin = hasAnyPermission(userProfileWithPermissions, ADMIN_ACCESS_PERMISSIONS);
+  const resolvedTenantId =
+    activeTenantId ||
+    userProfileWithPermissions.tenants?.[0]?.tenant?.id?.toString() ||
+    '1';
+  const resolvedUserEmail = userProfileWithPermissions.email || 'admin@bidexpert.ai';
 
   if (!canAccessAdmin) {
     return (
@@ -106,6 +112,11 @@ export function AdminLayoutClient({ children }: AdminLayoutClientProps) {
                 {children}
               </div>
             </main>
+            <DevInfoIndicator
+              mode="admin-fixed"
+              tenantId={resolvedTenantId}
+              userEmail={resolvedUserEmail}
+            />
             <AdminQueryMonitor />
           </div>
         </div>

--- a/src/app/api/admin/dev-info/route.ts
+++ b/src/app/api/admin/dev-info/route.ts
@@ -1,0 +1,114 @@
+/**
+ * @fileoverview Endpoint de diagnostico para exibir ambiente no rodape fixo do dashboard admin.
+ */
+
+import { NextResponse } from 'next/server';
+
+export const dynamic = 'force-dynamic';
+
+function normalizeUrl(url: string): string {
+  if (!url) {
+    return url;
+  }
+
+  if (url.startsWith('http://') || url.startsWith('https://')) {
+    return url;
+  }
+
+  return `https://${url}`;
+}
+
+function detectDatabaseSystem(databaseUrl: string): string {
+  const url = databaseUrl.toLowerCase();
+
+  if (url.includes('mysql://')) {
+    return 'MYSQL';
+  }
+
+  if (url.includes('postgres://') || url.includes('postgresql://')) {
+    return 'POSTGRESQL';
+  }
+
+  return 'UNKNOWN';
+}
+
+function detectDatabaseProvider(allUrls: string[]): string {
+  const normalized = allUrls.filter(Boolean).map((url) => url.toLowerCase());
+
+  if (normalized.some((url) => url.includes('neon.tech'))) {
+    return 'Neon';
+  }
+
+  if (normalized.some((url) => url.includes('supabase.co'))) {
+    return 'Supabase';
+  }
+
+  if (normalized.some((url) => url.startsWith('prisma://') || url.includes('prisma-data.net'))) {
+    return 'Prisma';
+  }
+
+  if (normalized.some((url) => url.includes('postgres://') || url.includes('postgresql://'))) {
+    return 'Prisma (PostgreSQL)';
+  }
+
+  if (normalized.some((url) => url.includes('mysql://'))) {
+    return 'Prisma (MySQL)';
+  }
+
+  return 'Prisma';
+}
+
+function detectBranch(remoteServerUrl: string): string {
+  const branchFromEnv =
+    process.env.NEXT_PUBLIC_SYSTEM_BRANCH ||
+    process.env.VERCEL_GIT_COMMIT_REF ||
+    process.env.NEXT_PUBLIC_VERCEL_GIT_COMMIT_REF ||
+    process.env.GIT_BRANCH ||
+    process.env.NEXT_PUBLIC_GIT_BRANCH ||
+    '';
+
+  if (branchFromEnv) {
+    return branchFromEnv;
+  }
+
+  if (remoteServerUrl.includes('bidexpert-demo') || remoteServerUrl.includes('demo')) {
+    return 'demo-stable';
+  }
+
+  return 'main';
+}
+
+function detectRemoteServerUrl(branch: string): string {
+  const remoteServerFromEnv =
+    process.env.NEXT_PUBLIC_REMOTE_SERVER_URL ||
+    process.env.NEXT_PUBLIC_APP_URL ||
+    process.env.APP_URL ||
+    (process.env.VERCEL_URL ? `https://${process.env.VERCEL_URL}` : '');
+
+  if (remoteServerFromEnv) {
+    return normalizeUrl(remoteServerFromEnv);
+  }
+
+  if (branch === 'main') {
+    return 'https://bidexpert.vercel.app';
+  }
+
+  return 'https://bidexpert-demo.vercel.app';
+}
+
+export async function GET() {
+  const databaseUrl = process.env.DATABASE_URL || '';
+  const directUrl = process.env.DIRECT_URL || '';
+  const postgresUrl = process.env.POSTGRES_URL || '';
+  const remoteServerPreview = detectRemoteServerUrl('demo-stable');
+  const branch = detectBranch(remoteServerPreview);
+  const remoteServerUrl = detectRemoteServerUrl(branch);
+
+  return NextResponse.json({
+    dbSystem: detectDatabaseSystem(databaseUrl),
+    dbProvider: detectDatabaseProvider([databaseUrl, directUrl, postgresUrl]),
+    project: process.env.NEXT_PUBLIC_PROJECT_NAME || process.env.VERCEL_PROJECT_ID || 'bidexpert',
+    remoteServerUrl,
+    branch,
+  });
+}

--- a/src/components/layout/dev-info-indicator.tsx
+++ b/src/components/layout/dev-info-indicator.tsx
@@ -3,12 +3,148 @@
  */
 'use client';
 
-export default function DevInfoIndicator() {
+import { useEffect, useMemo, useState } from 'react';
+
+type DevInfoIndicatorMode = 'flow' | 'admin-fixed';
+
+interface DevInfoIndicatorProps {
+  mode?: DevInfoIndicatorMode;
+  tenantId?: string;
+  userEmail?: string;
+}
+
+interface RuntimeEnvironmentInfo {
+  dbSystem: string;
+  dbProvider: string;
+  project: string;
+  remoteServerUrl: string;
+  branch: string;
+}
+
+const DEFAULT_RUNTIME_ENVIRONMENT: RuntimeEnvironmentInfo = {
+  dbSystem: 'MYSQL',
+  dbProvider: 'Prisma',
+  project: 'bidexpert',
+  remoteServerUrl: 'https://bidexpert-demo.vercel.app',
+  branch: 'demo-stable',
+};
+
+function normalizeUrl(url: string): string {
+  if (!url) {
+    return url;
+  }
+
+  if (url.startsWith('http://') || url.startsWith('https://')) {
+    return url;
+  }
+
+  return `https://${url}`;
+}
+
+function inferBranchByHost(): string {
+  if (typeof window === 'undefined') {
+    return DEFAULT_RUNTIME_ENVIRONMENT.branch;
+  }
+
+  const host = window.location.hostname.toLowerCase();
+  if (host.includes('demo')) {
+    return 'demo-stable';
+  }
+
+  return 'main';
+}
+
+function getInitialRuntimeEnvironment(): RuntimeEnvironmentInfo {
+  const branchFromEnv =
+    process.env.NEXT_PUBLIC_SYSTEM_BRANCH ||
+    process.env.NEXT_PUBLIC_VERCEL_GIT_COMMIT_REF ||
+    process.env.NEXT_PUBLIC_GIT_BRANCH ||
+    '';
+
+  const branch = branchFromEnv || inferBranchByHost();
+  const remoteServerUrlFromEnv =
+    process.env.NEXT_PUBLIC_REMOTE_SERVER_URL ||
+    process.env.NEXT_PUBLIC_APP_URL ||
+    '';
+  const remoteServerUrl = remoteServerUrlFromEnv
+    ? normalizeUrl(remoteServerUrlFromEnv)
+    : branch === 'main'
+      ? 'https://bidexpert.vercel.app'
+      : 'https://bidexpert-demo.vercel.app';
+
+  return {
+    ...DEFAULT_RUNTIME_ENVIRONMENT,
+    project: process.env.NEXT_PUBLIC_PROJECT_NAME || DEFAULT_RUNTIME_ENVIRONMENT.project,
+    branch,
+    remoteServerUrl,
+  };
+}
+
+export default function DevInfoIndicator({
+  mode = 'flow',
+  tenantId = '1',
+  userEmail = 'admin@bidexpert.ai',
+}: DevInfoIndicatorProps) {
+  const [runtimeEnvironment, setRuntimeEnvironment] = useState<RuntimeEnvironmentInfo>(
+    getInitialRuntimeEnvironment,
+  );
+
+  useEffect(() => {
+    let isMounted = true;
+
+    const fetchRuntimeEnvironment = async () => {
+      try {
+        const response = await fetch('/api/admin/dev-info', { cache: 'no-store' });
+
+        if (!response.ok) {
+          return;
+        }
+
+        const payload = (await response.json()) as Partial<RuntimeEnvironmentInfo>;
+
+        if (!isMounted) {
+          return;
+        }
+
+        setRuntimeEnvironment((previous) => ({
+          ...previous,
+          ...payload,
+        }));
+      } catch {
+        // noop: keep current fallback environment info
+      }
+    };
+
+    void fetchRuntimeEnvironment();
+
+    return () => {
+      isMounted = false;
+    };
+  }, []);
+
+  const footerClassName = useMemo(
+    () =>
+      mode === 'admin-fixed'
+        ? 'fixed left-0 right-0 z-[60] px-4 sm:px-6 md:px-8 bottom-[calc(var(--admin-query-monitor-height,0px)+0.5rem)]'
+        : 'mt-4 w-full',
+    [mode],
+  );
+
+  const indicatorPanelClassName =
+    mode === 'admin-fixed'
+      ? 'p-3 bg-muted/90 rounded-lg border w-full max-w-7xl mx-auto backdrop-blur supports-[backdrop-filter]:bg-muted/75'
+      : 'mt-4 p-4 bg-muted/50 rounded-lg border w-full max-w-4xl mx-auto';
+
+  const remoteServerLabel = runtimeEnvironment.remoteServerUrl.replace(/^https?:\/\//, '');
+
   return (
-    // Regular footer in the page flow (not fixed). Admin layout will add padding-bottom when Query Monitor is present
-    <footer className="mt-4 w-full" data-ai-id="dashboard-footer" data-testid="dev-info-indicator">
+    <footer
+      className={footerClassName}
+      data-ai-id="dashboard-footer"
+      data-testid="dev-info-indicator"
+    >
       <div
-        className="mt-4 p-4 bg-muted/50 rounded-lg border w-full max-w-4xl mx-auto"
+        className={indicatorPanelClassName}
         data-ai-id="dev-info-indicator-inner"
       >
         <p
@@ -18,7 +154,7 @@ export default function DevInfoIndicator() {
           Dev Info
         </p>
         <div
-          className="grid grid-cols-2 sm:grid-cols-4 gap-x-4 gap-y-2"
+          className="grid grid-cols-2 sm:grid-cols-4 lg:grid-cols-7 gap-x-4 gap-y-2"
           data-ai-id="dev-info-grid"
         >
           <div className="text-center sm:text-left" data-ai-id="dev-info-tenant">
@@ -27,10 +163,10 @@ export default function DevInfoIndicator() {
             </span>
             <p
               className="font-semibold text-primary truncate"
-              title="1"
+              title={tenantId}
               data-ai-id="dev-info-tenant-value"
             >
-              1
+              {tenantId}
             </p>
           </div>
           <div className="text-center sm:text-left" data-ai-id="dev-info-user">
@@ -39,10 +175,10 @@ export default function DevInfoIndicator() {
             </span>
             <p
               className="font-semibold text-primary truncate"
-              title="admin@bidexpert.ai"
+              title={userEmail}
               data-ai-id="dev-info-user-value"
             >
-              admin@bidexpert.ai
+              {userEmail}
             </p>
           </div>
           <div className="text-center sm:text-left" data-ai-id="dev-info-db">
@@ -51,11 +187,50 @@ export default function DevInfoIndicator() {
             </span>
             <p
               className="font-semibold text-primary truncate"
-              title="MYSQL"
+              title={runtimeEnvironment.dbSystem}
               data-ai-id="dev-info-db-value"
             >
-              MYSQL
+              {runtimeEnvironment.dbSystem}
             </p>
+          </div>
+          <div className="text-center sm:text-left" data-ai-id="dev-info-provider">
+            <span className="text-xs text-muted-foreground" data-ai-id="dev-info-provider-label">
+              Provider
+            </span>
+            <p
+              className="font-semibold text-primary truncate"
+              title={runtimeEnvironment.dbProvider}
+              data-ai-id="dev-info-provider-value"
+            >
+              {runtimeEnvironment.dbProvider}
+            </p>
+          </div>
+          <div className="text-center sm:text-left" data-ai-id="dev-info-branch">
+            <span className="text-xs text-muted-foreground" data-ai-id="dev-info-branch-label">
+              Branch
+            </span>
+            <p
+              className="font-semibold text-primary truncate"
+              title={runtimeEnvironment.branch}
+              data-ai-id="dev-info-branch-value"
+            >
+              {runtimeEnvironment.branch}
+            </p>
+          </div>
+          <div className="text-center sm:text-left" data-ai-id="dev-info-server-link">
+            <span className="text-xs text-muted-foreground" data-ai-id="dev-info-server-link-label">
+              Server
+            </span>
+            <a
+              href={runtimeEnvironment.remoteServerUrl}
+              target="_blank"
+              rel="noopener noreferrer"
+              className="font-semibold text-primary truncate hover:underline"
+              title={runtimeEnvironment.remoteServerUrl}
+              data-ai-id="dev-info-server-link-value"
+            >
+              {remoteServerLabel}
+            </a>
           </div>
           <div className="text-center sm:text-left" data-ai-id="dev-info-project">
             <span className="text-xs text-muted-foreground" data-ai-id="dev-info-project-label">
@@ -63,10 +238,10 @@ export default function DevInfoIndicator() {
             </span>
             <p
               className="font-semibold text-primary truncate"
-              title="bidexpert"
+              title={runtimeEnvironment.project}
               data-ai-id="dev-info-project-value"
             >
-              bidexpert
+              {runtimeEnvironment.project}
             </p>
           </div>
         </div>

--- a/src/components/support/admin-query-monitor.tsx
+++ b/src/components/support/admin-query-monitor.tsx
@@ -9,7 +9,6 @@ import { Button } from '@/components/ui/button';
 import { Badge } from '@/components/ui/badge';
 import { cn } from '@/lib/utils';
 import { toast } from 'sonner';
-import DevInfoIndicator from '@/components/layout/dev-info-indicator';
 
 interface QueryLog {
   id: string;
@@ -210,9 +209,6 @@ export default function AdminQueryMonitor() {
       >
         <div className="h-full overflow-y-auto p-4 scrollbar-thin scrollbar-thumb-slate-700 scrollbar-track-transparent">
           <div className="space-y-4" data-ai-id="query-monitor-content">
-            <div data-ai-id="query-monitor-dev-info">
-              <DevInfoIndicator />
-            </div>
             {queries.length === 0 ? (
               <div className="h-full flex flex-col items-center justify-center text-slate-500 py-12">
                 <Database className="h-12 w-12 mb-3 opacity-20" />

--- a/tests/unit/components/admin-query-monitor.test.tsx
+++ b/tests/unit/components/admin-query-monitor.test.tsx
@@ -39,8 +39,10 @@ describe('AdminQueryMonitor', () => {
     expect(document.documentElement.style.getPropertyValue('--admin-query-monitor-height')).toBe('48px');
   });
 
-  it('renders Dev Info inside the monitor', async () => {
+  it('does not render Dev Info inside the monitor by default', async () => {
     render(<AdminQueryMonitor />);
-    expect(await screen.findByText('Dev Info')).toBeInTheDocument();
+    await waitFor(() => {
+      expect(screen.queryByText('Dev Info')).not.toBeInTheDocument();
+    });
   });
 });


### PR DESCRIPTION
## Resumo\n- Move Dev Info para rodapé fixo do dashboard admin\n- Remove Dev Info de dentro do Query Monitor\n- Adiciona endpoint /api/admin/dev-info para informar DB system/provider, branch e server link\n- Exibe branch vinculada (demo-stable/main) e link do servidor remoto no bloco\n\n## Validação\n- npm run typecheck ✅\n- Vitest: falha de setup pré-existente (ria-query export mismatch em itest.setup.ts)