### PR TITLE
fix: remove generateStaticParams from category redirect page

### DIFF
--- a/src/app/category/[categorySlug]/page.tsx
+++ b/src/app/category/[categorySlug]/page.tsx
@@ -1,21 +1,12 @@
-﻿import { redirect } from 'next/navigation';
-import { getLotCategories } from '@/app/admin/categories/actions';
+﻿/**
+ * Category redirect page — redirects /category/[slug] to /search?category=[slug]
+ * Uses force-dynamic since tenant resolution depends on request context.
+ * No generateStaticParams needed — this page only redirects.
+ */
+import { redirect } from 'next/navigation';
 
 export const dynamic = 'force-dynamic';
 
-// This page component is a Server Component
 export default function CategoryPage({ params }: { params: { categorySlug: string } }) {
   redirect(`/search?category=${params.categorySlug}`);
-}
-
-export async function generateStaticParams() {
-  try {
-    const categories = await getLotCategories();
-    return categories.map(category => ({
-      categorySlug: category.slug,
-    }));
-  } catch (error) {
-    console.error("Failed to generate static params for categories:", error);
-    return []; 
-  }
 }


### PR DESCRIPTION
## Fix: Remove generateStaticParams from category redirect page

### Problem
Vercel build logs show error during `Collecting page data` phase:
```
[getLotCategories] Error: `cookies` was called outside a request scope
    at generateStaticParams (category/[categorySlug]/page.js)
```

### Root Cause
`generateStaticParams()` in `src/app/category/[categorySlug]/page.tsx` calls:
- `getLotCategories()` → `getTenantIdFromRequest(true)` → `getSession()` → `cookies()`

At build time, there's no HTTP request context, so `cookies()` fails.

### Fix
Removed `generateStaticParams()` entirely — the page only redirects to `/search?category=[slug]`, so static generation is unnecessary and counterproductive.

### Impact
- Eliminates build-time error on Vercel
- No functional change (page still redirects correctly)
- Cleaner build logs