### PR TITLE
fix: lot edit 404 for landlord admin on Vercel

### DIFF
--- a/src/app/admin/lots/actions.ts
+++ b/src/app/admin/lots/actions.ts
@@ -13,6 +13,7 @@ import { revalidatePath } from 'next/cache';
 import { LotService } from '@/services/lot.service';
 import { AssetService } from '@/services/asset.service';
 import { getTenantIdFromRequest } from '@/lib/actions/auth';
+import { getSession } from '@/server/lib/session';
 import { sanitizeResponse } from '@/lib/serialization-helper';
 
 const lotService = new LotService();
@@ -34,7 +35,19 @@ export async function getLots(filter?: { auctionId?: string; judicialProcessId?:
 export async function getLot(id: string, isPublicCall: boolean = false): Promise<Lot | null> {
   const tenantId = isPublicCall ? await getTenantIdFromRequest(true) : await getTenantIdFromRequest(false);
   console.log(`[Action getLot] ID: ${id}, Public: ${isPublicCall}, Tenant: ${tenantId}`);
-  return lotService.getLotById(id, tenantId, isPublicCall);
+  const lot = await lotService.getLotById(id, tenantId, isPublicCall);
+
+  // Landlord admin fallback: if lot not found due to tenant mismatch,
+  // retry without tenant filter (landlord admins can manage all tenants)
+  if (!lot && !isPublicCall) {
+    const session = await getSession();
+    if (session?.tenantId === '1') {
+      console.log(`[Action getLot] Landlord fallback for ID: ${id}`);
+      return lotService.getLotById(id, undefined, false);
+    }
+  }
+
+  return lot;
 }
 
 export async function createLot(data: Partial<LotFormData>): Promise<{ success: boolean; message: string; lotId?: string }> {

--- a/src/app/auctions/[auctionId]/lots/[lotId]/lot-detail-client.tsx
+++ b/src/app/auctions/[auctionId]/lots/[lotId]/lot-detail-client.tsx
@@ -408,7 +408,7 @@ export default function LotDetailClientContent({
       {
         id: 'edit-lot',
         label: 'Editar Lote',
-        href: `/admin/lots/${lot.id}/edit`,
+        href: `/admin/lots/${lot.publicId || lot.id}/edit`,
         icon: Pencil,
         dataAiId: 'floating-action-edit-lot',
       },


### PR DESCRIPTION
## Problema\n\nAo tentar editar um lote no Vercel (`/admin/lots/<publicId>/edit`), a página retornava 404.\n\n## Causa Raiz\n\nNo Vercel, o middleware resolve o tenant como `'1'` (landlord) quando `NEXT_PUBLIC_DEFAULT_TENANT` não está configurado. Para admins landlord (session.tenantId='1'), a action `getLot` passava tenantId='1' para `getLotById`, que fazia `lot.tenantId !== tenantId` → `'3' !== '1'` → retornava null → 404.\n\n## Correção\n\n### 1. `src/app/admin/lots/actions.ts`\n- Adicionado fallback para landlord admin: quando o lote não é encontrado e `session.tenantId === '1'`, retenta a busca sem filtro de tenant (landlord admins gerenciam todos os tenants)\n\n### 2. `src/app/auctions/[auctionId]/lots/[lotId]/lot-detail-client.tsx`\n- Corrigido link de edição para usar `publicId || id` (consistente com o padrão já usado em `admin/lots/columns.tsx`)\n\n## Validação\n- ✅ Build local passou sem erros\n- ✅ Prisma generate OK\n- ✅ Alteração mínima e focada no problema