### PR TITLE
fix: resolve 7+ Vercel CRUD 500 errors (audit model, LotRisk, visitor updatedAt, middleware logs, bid SET LOCAL)

### DIFF
--- a/src/app/api/admin/query-monitor/route.ts
+++ b/src/app/api/admin/query-monitor/route.ts
@@ -19,8 +19,7 @@ export async function GET(req: NextRequest) {
     // Get recent query logs (last 100 queries)
     let queryLogs: any[] = [];
     try {
-      // @ts-ignore - Handle prisma model name mismatch between databases
-      const model = prisma.itsm_query_logs ?? prisma.iTSM_QueryLog;
+      const model = (prisma as any).itsm_query_logs;
       if (model) {
         queryLogs = await model.findMany({
           take: 100,
@@ -80,8 +79,7 @@ export async function POST(req: NextRequest) {
     const body = await req.json();
     const { query, duration, success, errorMessage, userId, endpoint, method, ipAddress } = body;
 
-    // @ts-ignore
-    await (prisma.itsm_query_logs || prisma.iTSM_QueryLog).create({
+    await (prisma as any).itsm_query_logs.create({
       data: {
         query,
         duration,

--- a/src/lib/auction-state-machine/audit-log.service.ts
+++ b/src/lib/auction-state-machine/audit-log.service.ts
@@ -32,7 +32,7 @@ export async function createStateAuditLog(
     // Mapear action string para audit_logs_action enum
     const actionEnum = mapActionToEnum(entry.action);
 
-    await (tx as PrismaClient).audit_logs.create({
+    await (tx as unknown as Record<string, any>).auditLog.create({
       data: {
         entityType: entry.entityType,
         entityId: entry.entityId,

--- a/src/lib/observability/audit-extension.ts
+++ b/src/lib/observability/audit-extension.ts
@@ -70,9 +70,8 @@ export const auditExtension = Prisma.defineExtension((client) => {
                 // We use 'prisma.audit_logs.create' but we are inside extension of client.
                 // context.prisma.audit_logs.create ...
                 
-                // This requires a separate non-extended client avoid recursion loop if we audit the audit_logs table!
-                // So we should check if model === 'audit_logs'.
-                if (model === 'audit_logs' || model === 'AuditConfig') return;
+                // This requires a separate non-extended client to avoid recursion loop if we audit the AuditLog table!
+                if (model === 'AuditLog' || model === 'AuditConfig') return;
 
                  // Using a raw query or a separate client reference would be safer to avoid infinite loops
                  // But since we excluded 'audit_logs', it's safe.

--- a/src/middleware.ts
+++ b/src/middleware.ts
@@ -92,12 +92,9 @@ async function resolveTenantFromRequest(
   const normalizedHost = effectiveHost.toLowerCase();
   const hostWithoutPort = normalizedHost.replace(/:\d+$/, ''); // Remove porta
 
-  console.log(`[resolveTenantFromRequest] hostname='${hostname}', forwardedHost='${forwardedHost}', effectiveHost='${effectiveHost}', hostWithoutPort='${hostWithoutPort}'`);
-
   // 1. Check for localhost subdomain pattern: [subdomain].localhost or [subdomain].localhost:port
   // This supports demo.localhost:3000, crm.localhost:9002, etc.
   const localhostSubdomainMatch = hostWithoutPort.match(/^([a-z0-9-]+)\.localhost$/i);
-  console.log(`[resolveTenantFromRequest] localhostSubdomainMatch:`, localhostSubdomainMatch);
   if (localhostSubdomainMatch) {
     const subdomain = normalizeTenantToken(localhostSubdomainMatch[1]);
     if (!subdomain) {
@@ -245,10 +242,6 @@ export async function middleware(req: NextRequest) {
   // Obtém a sessão do usuário (se logado)
   const session = await getSession();
   
-  // DEBUG: Log session state
-  console.log(`[Middleware] Resolution: tenantId='${resolution.tenantId}', subdomain='${resolution.subdomain}'`);
-  console.log(`[Middleware] Session: ${session ? `tenantId='${session.tenantId}', userId='${session.userId}'` : 'null'}`);
-  
   // O tenant da URL/subdomain SEMPRE tem precedência para garantir isolamento multi-tenant correto.
   // A sessão só é usada para validar se o usuário logado pertence ao tenant acessado.
   // Se a URL resolve para um subdomain/tenant específico, esse é o tenant ativo.
@@ -258,8 +251,6 @@ export async function middleware(req: NextRequest) {
   // Se a resolução retornou um slug (não numérico), mantém para lookup posterior
   // Se retornou LANDLORD_ID, e usuário tem sessão de outro tenant, mantém landlord
   // Isso garante que demo.localhost sempre use tenant "demo" (depois resolvido para ID 3)
-  
-  console.log(`[Middleware] Active Tenant ID set to: '${activeTenantId}'`);
   
   // Prepara headers para a requisição
   const requestHeaders = new Headers(req.headers);

--- a/src/repositories/bid.repository.ts
+++ b/src/repositories/bid.repository.ts
@@ -13,10 +13,13 @@ export class BidRepository {
 
     // Transação Atômica com Auditoria e Trava Otimista
     return await prisma.$transaction(async (tx) => {
-      // 1. Auditoria: Seta o usuário da sessão para o pgAudit logar
-      // Proteção contra SQL injection via parâmetros (embora aqui seja numérico/string controlado)
-      await tx.$executeRaw`SET LOCAL app.current_user_id = ${bidderIdStr}`;
-      await tx.$executeRaw`SET LOCAL app.current_tenant_id = ${tenantId?.toString() || '0'}`;
+      // 1. Auditoria: Seta o usuário da sessão para o pgAudit logar (PostgreSQL only)
+      try {
+        await tx.$executeRaw`SET LOCAL app.current_user_id = ${bidderIdStr}`;
+        await tx.$executeRaw`SET LOCAL app.current_tenant_id = ${tenantId?.toString() || '0'}`;
+      } catch {
+        // SET LOCAL is PostgreSQL-specific; silently skip on MySQL
+      }
 
       // 2. Atomic Update aka "Check-and-Set"
       // Tenta atualizar o Lote APENAS SE o novo lance for maior que o preço atual (ou inicial)

--- a/src/services/audit.service.ts
+++ b/src/services/audit.service.ts
@@ -37,17 +37,16 @@ export class AuditService {
     newValues?: Record<string, any>
   ): Promise<void> {
     try {
-      // @ts-ignore - prisma.audit_logs might be typed differently based on generation
-      await prisma.audit_logs.create({
+      await (prisma as any).auditLog.create({
         data: {
           tenantId: BigInt(tenantId),
           userId: BigInt(userId),
           entityType,
-          action: action as any, // Enum casing might differ
+          action: action as any,
           entityId: BigInt(entityId),
-          changes: changes ? JSON.stringify(changes) : Prisma.JsonNull,
-          oldValues: oldValues ? JSON.stringify(oldValues) : Prisma.JsonNull,
-          newValues: newValues ? JSON.stringify(newValues) : Prisma.JsonNull,
+          changes: changes ?? Prisma.JsonNull,
+          oldValues: oldValues ?? Prisma.JsonNull,
+          newValues: newValues ?? Prisma.JsonNull,
           traceId: traceId || null,
           timestamp: new Date(),
           ipAddress,
@@ -99,8 +98,7 @@ export class AuditService {
       offset = 0,
     } = options;
 
-    // @ts-ignore
-    const logs = await prisma.audit_logs.findMany({
+    const logs = await (prisma as any).auditLog.findMany({
       where: {
         tenantId: BigInt(tenantId),
         ...(userId && { userId: BigInt(userId) }),
@@ -150,8 +148,7 @@ export class AuditService {
     const startDate = new Date();
     startDate.setDate(startDate.getDate() - days);
 
-    // @ts-ignore
-    const logs = await prisma.audit_logs.groupBy({
+    const logs = await (prisma as any).auditLog.groupBy({
       by: ['entityType', 'action'],
       where: {
         tenantId: BigInt(tenantId),
@@ -174,8 +171,7 @@ export class AuditService {
     const cutoffDate = new Date();
     cutoffDate.setDate(cutoffDate.getDate() - olderThanDays);
 
-    // @ts-ignore
-    const result = await prisma.audit_logs.deleteMany({
+    const result = await (prisma as any).auditLog.deleteMany({
       where: {
         tenantId: BigInt(tenantId),
         timestamp: { lt: cutoffDate },

--- a/src/services/lot.service.ts
+++ b/src/services/lot.service.ts
@@ -745,9 +745,7 @@ export class LotService {
       }
 
         if (Array.isArray(lotRisks) && lotRisks.length > 0) {
-          const prismaAny = this.prisma as unknown as Record<string, any>;
-          const lotRiskModel = prismaAny['lotRisk'] ?? prismaAny['lotRisks'];
-          await lotRiskModel.createMany({
+          await (this.prisma as any).lotRisk.createMany({
           data: lotRisks.map((risk: any) => ({
             lotId,
             tenantId: BigInt(tenantId),
@@ -757,6 +755,7 @@ export class LotService {
             mitigationStrategy: risk.mitigationStrategy || null,
             verified: Boolean(risk.verified),
             verifiedAt: risk.verified ? new Date() : null,
+            updatedAt: new Date(),
           })),
         });
       }

--- a/src/services/shadow-ban.service.ts
+++ b/src/services/shadow-ban.service.ts
@@ -132,7 +132,7 @@ export async function applyShadowBan(
     });
 
     // Log de auditoria (usando UPDATE pois shadow ban é uma alteração de estado)
-    await prisma.audit_logs.create({
+    await (prisma as any).auditLog.create({
       data: {
         action: 'UPDATE',
         entityType: 'User',
@@ -205,7 +205,7 @@ export async function removeShadowBan(
     });
 
     // Log de auditoria (usando UPDATE pois shadow ban é uma alteração de estado)
-    await prisma.audit_logs.create({
+    await (prisma as any).auditLog.create({
       data: {
         action: 'UPDATE',
         entityType: 'User',

--- a/src/services/visitor-tracking.service.ts
+++ b/src/services/visitor-tracking.service.ts
@@ -107,6 +107,7 @@ export class VisitorTrackingService {
           country: geoData.country,
           region: geoData.region,
           city: geoData.city,
+          updatedAt: new Date(),
         }
       });
 
@@ -136,6 +137,7 @@ export class VisitorTrackingService {
           country: geoData.country,
           region: geoData.region,
           city: geoData.city,
+          updatedAt: new Date(),
         }
       });
 


### PR DESCRIPTION
# Fix: Vercel CRUD 500 Errors

## Problema
Múltiplos erros 500 nos CRUDs em produção (Vercel) causados por nomes de modelo Prisma incorretos, campos obrigatórios faltando, e SQL incompatível.

## Correções (9 arquivos, 26 inserções, 38 deleções)

| Arquivo | Correção |
|---------|----------|
| `src/services/audit.service.ts` | `prisma.audit_logs` → `prisma.auditLog` (4x) + removido `JSON.stringify` duplo em campos Json |
| `src/services/shadow-ban.service.ts` | `prisma.audit_logs` → `prisma.auditLog` (2x) |
| `src/lib/auction-state-machine/audit-log.service.ts` | `tx.audit_logs` → `tx.auditLog` |
| `src/lib/observability/audit-extension.ts` | Guard `'audit_logs'` → `'AuditLog'` (previne recursão infinita) |
| `src/app/api/admin/query-monitor/route.ts` | Fallback chain morta → acesso direto `itsm_query_logs` |
| `src/services/lot.service.ts` | LotRisk model guessing → acesso direto + `updatedAt: new Date()` |
| `src/services/visitor-tracking.service.ts` | `updatedAt: new Date()` nos 2 `create()` |
| `src/repositories/bid.repository.ts` | `SET LOCAL` em try-catch (sintaxe PG-only) |
| `src/middleware.ts` | 5 `console.log` removidos (poluição de logs em produção) |

## Categorias de Bug Corrigidas
1. **Wrong Prisma model accessor** — `audit_logs` não existe como accessor; o correto é `auditLog`
2. **Dead code fallbacks** com `@ts-ignore` mascarando erros reais
3. **JSON double-encoding** — `JSON.stringify()` em campos que Prisma já serializa como Json
4. **Missing `updatedAt`** em models com `@updatedAt` sem `@default`
5. **PostgreSQL-only SQL** (`SET LOCAL`) quebrando em MySQL dev
6. **Log pollution** — 5 console.log no middleware disparando em TODA request

## Verificação
- ✅ `npx prisma generate` — OK
- ✅ `npm run typecheck` — zero erros novos (todos pré-existentes)
- ✅ `npm run build` — compilação bem-sucedida