### PR TITLE
fix: lot images inconsistent - CoverImage, deep AssetMedia include, phantom field stripping, PascalCase relations

### DIFF
--- a/src/services/lot.service.ts
+++ b/src/services/lot.service.ts
@@ -527,9 +527,17 @@ export class LotService {
                 LotStagePrice: true,
                 AssetsOnLots: {
                     include: {
-                        Asset: true
+                        Asset: {
+                            include: {
+                                AssetMedia: {
+                                    include: { MediaItem: true },
+                                    orderBy: { displayOrder: 'asc' }
+                                }
+                            }
+                        }
                     }
                 },
+                CoverImage: true,
                 LotRisk: true,
                 LotDocument: {
                     orderBy: { displayOrder: 'asc' }
@@ -691,29 +699,38 @@ export class LotService {
           updatedAt: new Date(),
       };
 
+      // Strip phantom fields that don't exist on the Prisma Lot model
+      const phantomLotFields = [
+        'id', 'auctionName', 'properties', 'inheritedMediaFromAssetId',
+        'originalLotId', 'Auction', 'Auctioneer', 'LotCategory', 'City',
+        'State', 'Seller', 'Subcategory', 'Tenant', 'CoverImage', 'User',
+        'AssetsOnLots', 'Bid', 'LotDocument', 'LotQuestion', 'LotRisk',
+        'LotStagePrice', 'Notification', 'Review', 'UserLotMaxBid',
+        'UserWin', 'InstallmentPayment', 'JudicialProcess',
+        'auction', 'seller', 'auctioneer', 'category', 'subcategory',
+        'city', 'state', 'tenant', '_count', 'Lot', 'other_Lot',
+      ];
+      for (const key of phantomLotFields) {
+        delete createData[key];
+      }
+
       if (cleanData.categoryId) {
         createData.categoryId = BigInt(cleanData.categoryId);
-        delete createData.category;
       }
       if (cleanData.subcategoryId) {
         createData.subcategoryId = BigInt(cleanData.subcategoryId);
-        delete createData.subcategory;
       }
       if (cleanData.sellerId) {
         createData.sellerId = BigInt(cleanData.sellerId);
-        delete createData.seller;
       }
       if (cleanData.auctioneerId) {
         createData.auctioneerId = BigInt(cleanData.auctioneerId);
-        delete createData.auctioneer;
       }
       if (cleanData.cityId) {
         createData.cityId = BigInt(cleanData.cityId);
-        delete createData.city;
       }
       if (cleanData.stateId) {
         createData.stateId = BigInt(cleanData.stateId);
-        delete createData.state;
       }
 
 
@@ -774,9 +791,17 @@ export class LotService {
                 LotStagePrice: true,
                 AssetsOnLots: {
                     include: {
-                        Asset: true
+                        Asset: {
+                            include: {
+                                AssetMedia: {
+                                    include: { MediaItem: true },
+                                    orderBy: { displayOrder: 'asc' }
+                                }
+                            }
+                        }
                     }
                 },
+                CoverImage: true,
                 _count: {
                     select: { Bid: true }
                 }
@@ -802,22 +827,56 @@ export class LotService {
         ...cleanData 
       } = data as any;
       
+      // Strip phantom fields that don't exist on the Prisma Lot model
+      const phantomLotFields = [
+        'id', 'auctionName', 'properties', 'inheritedMediaFromAssetId',
+        'originalLotId', 'Auction', 'Auctioneer', 'LotCategory', 'City',
+        'State', 'Seller', 'Subcategory', 'Tenant', 'CoverImage', 'User',
+        'AssetsOnLots', 'Bid', 'LotDocument', 'LotQuestion', 'LotRisk',
+        'LotStagePrice', 'Notification', 'Review', 'UserLotMaxBid',
+        'UserWin', 'InstallmentPayment', 'JudicialProcess',
+        'auction', 'seller', 'auctioneer', 'category', 'subcategory',
+        'city', 'state', 'tenant', '_count', 'Lot', 'other_Lot',
+        'tenantId',
+      ];
+      for (const key of phantomLotFields) {
+        delete cleanData[key];
+      }
+
       const updateRelations: Record<string, any> = {};
-      
+
       if (auctionId) {
-        updateRelations.auction = { connect: { id: BigInt(auctionId) } };
+        updateRelations.Auction = { connect: { id: BigInt(auctionId) } };
       }
-      
+
       if (cleanData.categoryId) {
-        updateRelations.category = { connect: { id: BigInt(cleanData.categoryId) } };
+        updateRelations.LotCategory = { connect: { id: BigInt(cleanData.categoryId) } };
+        delete cleanData.categoryId;
       }
-      
+
       if (cleanData.subcategoryId) {
-        updateRelations.subcategory = { connect: { id: BigInt(cleanData.subcategoryId) } };
+        updateRelations.Subcategory = { connect: { id: BigInt(cleanData.subcategoryId) } };
+        delete cleanData.subcategoryId;
       }
-      
+
       if (cleanData.sellerId) {
-        updateRelations.seller = { connect: { id: BigInt(cleanData.sellerId) } };
+        updateRelations.Seller = { connect: { id: BigInt(cleanData.sellerId) } };
+        delete cleanData.sellerId;
+      }
+
+      if (cleanData.auctioneerId) {
+        updateRelations.Auctioneer = { connect: { id: BigInt(cleanData.auctioneerId) } };
+        delete cleanData.auctioneerId;
+      }
+
+      if (cleanData.cityId) {
+        updateRelations.City = { connect: { id: BigInt(cleanData.cityId) } };
+        delete cleanData.cityId;
+      }
+
+      if (cleanData.stateId) {
+        updateRelations.State = { connect: { id: BigInt(cleanData.stateId) } };
+        delete cleanData.stateId;
       }
       
       await this.prisma.$transaction(async (tx) => {


### PR DESCRIPTION
## Contexto
Cherry-pick focado das correções de imagens de lotes extraídas da PR #439 (que tinha 80+ arquivos não relacionados).

## Mudanças (1 arquivo: `src/services/lot.service.ts`)

### 1. Deep Asset Include com AssetMedia (2 locais)
- `getLots()` e `getLotsByIds()`: `Asset: true` → `Asset: { include: { AssetMedia: { include: { MediaItem: true }, orderBy: { displayOrder: 'asc' } } } }`
- Garante que cards, preview e detail page tenham acesso às mídias dos ativos

### 2. CoverImage: true (2 locais)
- Adicionado nos includes de `getLots()` e `getLotsByIds()`
- Corrige inconsistência de imagem de capa entre card, quick preview e detail

### 3. Phantom Field Stripping no createLot
- Substitui `delete createData.category` individuais por array completo de campos fantasma
- Previne erros Prisma ao tentar inserir campos de relação como colunas

### 4. PascalCase Relation Names no updateLot
- `auction` → `Auction`, `category` → `LotCategory`, `subcategory` → `Subcategory`, `seller` → `Seller`
- Adiciona relações faltantes: `Auctioneer`, `City`, `State`
- Nomes agora correspondem exatamente ao schema Prisma

## Notas
- Erros de typecheck pré-existentes (`BidInfo[]`, `Review[]`, `LotQuestion[]`) não foram introduzidos por esta PR
- Substitui a PR #439 (draft com 80+ arquivos) — apenas o fix relevante do `lot.service.ts`