### PR TITLE
fix: remove 'use server' from safe-action.ts factory utility

### DIFF
--- a/src/lib/admin-plus/safe-action.ts
+++ b/src/lib/admin-plus/safe-action.ts
@@ -3,7 +3,6 @@
  * Fornece createAdminAction que encapsula autenticação, permissões,
  * validação Zod e tratamento de erros em um resultado padronizado ActionResult.
  */
-'use server';
 
 import { z } from 'zod';
 import type { ActionResult } from './types';


### PR DESCRIPTION
## Fix: Remove 'use server' from safe-action.ts\n\n### Problem\nVercel build fails with:\n```\nServer actions must be async functions\n```\nat `src/lib/admin-plus/safe-action.ts` line 44 (`createAdminAction`).\n\n### Root Cause\n`safe-action.ts` has `'use server'` at file level, but `createAdminAction` is a **synchronous factory function** that returns async server action functions. Next.js SWC compiler requires all exports from `'use server'` files to be async.\n\n### Fix\nRemove `'use server'` from `safe-action.ts`. All 63 entity `actions.ts` files already have their own `'use server'` directives — the factory utility does not need it.\n\n### Changes\n- `src/lib/admin-plus/safe-action.ts`: Removed `'use server'` directive (1 line deletion)