### PR TITLE
docs: enforce shared memory preflight across agents

### DIFF
--- a/.agent/workflows/parallel-development.md
+++ b/.agent/workflows/parallel-development.md
@@ -36,6 +36,21 @@ repositório (.git compartilhado)
 
 ## 📋 Checklist Obrigatório — INÍCIO de Cada Task
 
+### Passo 0.0 — Verificar Memória Compartilhada (OBRIGATÓRIO)
+
+Antes de criar worktree, subir ambiente ou editar qualquer arquivo, o agente DEVE revisar os **últimos 30 dias** de contexto compartilhado em:
+
+1. `/memories/repo/shared-memory-preflight.md`
+2. `/memories/repo/active-agent-sessions.md`
+3. `/memories/repo/recent-agent-changes.md`
+4. `/memories/repo/windows-worktree-notes.md`
+5. `.coordination/queue.yaml`
+6. `.coordination/ownership-map.yaml`
+
+Se houver handoff recente, conflito potencial ou dúvida sobre atividade paralela, consultar também `.coordination/master-events.ndjson` e o histórico recente da branch/área antes de continuar.
+
+> **REGRA:** Nenhuma sessão pode iniciar ou continuar sem concluir este passo e registrar sua própria atividade em `/memories/repo/active-agent-sessions.md`.
+
 ### Passo 0.1 — Protocolo Anti-Erros Reais
 
 Antes de diagnosticar bug de página, login ou teste, o agente DEVE executar este filtro:

--- a/.claude/CLAUDE.md
+++ b/.claude/CLAUDE.md
@@ -4,6 +4,13 @@ Instructions here apply to this project and are shared with team members.
 
 ## Context
 
+### Shared Memory Preflight (Mandatory)
+
+- Before any new or resumed task, review the last 30 days in `/memories/repo/shared-memory-preflight.md`, `/memories/repo/active-agent-sessions.md`, `/memories/repo/recent-agent-changes.md`, and `/memories/repo/windows-worktree-notes.md`.
+- Check `.coordination/queue.yaml` and `.coordination/ownership-map.yaml` before assuming a work area is free; use `.coordination/master-events.ndjson` when recent activity is unclear.
+- Register the current session in `/memories/repo/active-agent-sessions.md` before editing files, then append blockers, scope changes, and handoff notes to `/memories/repo/recent-agent-changes.md`.
+- No Claude session may start or continue implementation without completing this preflight.
+
 ### Operational Guardrails Learned from Admin-Plus Sweep (2026-03)
 
 - Before editing any route after `ERR_CONNECTION_REFUSED`, confirm the server is still alive. Cascading route failures after many previous `200` responses usually mean process crash or OOM, not many simultaneous page bugs.

--- a/.gemini/GEMINI.md
+++ b/.gemini/GEMINI.md
@@ -6,6 +6,18 @@
 Todas as regras detalhadas estão em:
 `E:\SmartDataCorp\BidExpert\BidExpertVsCode\bidexpert_ai_firebase_studio\.github\copilot-instructions.md`
 
+## 🧠 Preflight Obrigatório de Memória Compartilhada
+
+Antes de iniciar ou continuar qualquer implementação, alteração, correção ou investigação, agentes Gemini DEVEM revisar os **últimos 30 dias** de contexto compartilhado em:
+1. `/memories/repo/shared-memory-preflight.md`
+2. `/memories/repo/active-agent-sessions.md`
+3. `/memories/repo/recent-agent-changes.md`
+4. `/memories/repo/windows-worktree-notes.md`
+5. `.coordination/queue.yaml`
+6. `.coordination/ownership-map.yaml`
+
+Se houver handoff, atividade paralela ou conflito potencial, consultar também `.coordination/master-events.ndjson` e o histórico recente da branch/área. Antes de editar arquivos, o agente Gemini DEVE registrar sua sessão atual em `/memories/repo/active-agent-sessions.md`.
+
 ---
 
 ## 🚨 Protocolo Anti-Erros Reais (MÁXIMA PRIORIDADE)

--- a/.github/ANTIGRAVITY-AUTOMATION.md
+++ b/.github/ANTIGRAVITY-AUTOMATION.md
@@ -10,13 +10,17 @@ This document describes how the Auction Sniper & QA Agent integrates with Google
 
 Before any Antigravity workflow opens fixes, files issues, or suggests code changes, it MUST classify the incident correctly:
 
-1. Confirm the active runtime belongs to the intended isolated environment or worktree.
-2. Validate runtime baseline for login/E2E: `DATABASE_URL`, `SESSION_SECRET`, `AUTH_SECRET`, `NEXTAUTH_SECRET`.
-3. Probe `/auth/login` and `/api/public/tenants` before assuming application regression.
-4. Treat cascaded `ERR_CONNECTION_REFUSED` as infrastructure failure, dead process, wrong port, or OOM until proven otherwise.
-5. If multiple Admin Plus routes show `input` or `ctx` `undefined`, inspect `src/lib/admin-plus/safe-action.ts` before opening route-specific fixes.
-6. Confirm Prisma field names from schema before suggesting `select`/`include` changes.
-7. Validation order for automated remediation: focused route reproduction → browser/server log correlation → code fix → focused rerun → broader sweep.
+1. Review the last 30 days in `/memories/repo/shared-memory-preflight.md`, `/memories/repo/active-agent-sessions.md`, `/memories/repo/recent-agent-changes.md`, and `/memories/repo/windows-worktree-notes.md` before opening fixes or suggesting remediation.
+2. Check `.coordination/queue.yaml` and `.coordination/ownership-map.yaml` to avoid duplicate or conflicting automated work. Use `.coordination/master-events.ndjson` when recent activity is unclear.
+3. Confirm the active runtime belongs to the intended isolated environment or worktree.
+4. Validate runtime baseline for login/E2E: `DATABASE_URL`, `SESSION_SECRET`, `AUTH_SECRET`, `NEXTAUTH_SECRET`.
+5. Probe `/auth/login` and `/api/public/tenants` before assuming application regression.
+6. Treat cascaded `ERR_CONNECTION_REFUSED` as infrastructure failure, dead process, wrong port, or OOM until proven otherwise.
+7. If multiple Admin Plus routes show `input` or `ctx` `undefined`, inspect `src/lib/admin-plus/safe-action.ts` before opening route-specific fixes.
+8. Confirm Prisma field names from schema before suggesting `select`/`include` changes.
+9. Validation order for automated remediation: focused route reproduction → browser/server log correlation → code fix → focused rerun → broader sweep.
+
+If Antigravity opens an issue, proposes a fix, or hands work off to another agent, it MUST append a concise summary to `/memories/repo/recent-agent-changes.md` so later sessions can see the automation history.
 
 Antigravity MUST NOT open multiple page-level fixes when the root cause is a dead server, wrong runtime, or shared wrapper bug.
 

--- a/.github/copilot-instructions.md
+++ b/.github/copilot-instructions.md
@@ -10,6 +10,19 @@ Permitir que **múltiplos desenvolvedores** (humanos ou agentes AI) trabalhem **
 - ✅ Sua própria **porta de desenvolvimento** (9005, 9006, 9007, etc.)
 - ✅ Seus próprios **testes isolados**
 
+## 🧠 Preflight Obrigatório: Memória Compartilhada
+
+> **REGRA CRÍTICA:** Nenhuma sessão de chat pode iniciar ou continuar trabalho no BidExpert sem antes verificar a memória compartilhada e o contexto recente do repositório.
+
+Antes de qualquer implementação, correção, revisão ou retomada de task, o agente DEVE:
+1. Ler os registros dos **últimos 30 dias** em `/memories/repo/shared-memory-preflight.md`, `/memories/repo/active-agent-sessions.md`, `/memories/repo/recent-agent-changes.md` e `/memories/repo/windows-worktree-notes.md`.
+2. Conferir `.coordination/queue.yaml` e `.coordination/ownership-map.yaml` para identificar trabalho concorrente, ownership e risco de conflito. Quando houver dúvida sobre eventos recentes, consultar também `.coordination/master-events.ndjson`.
+3. Revisar a branch ativa, worktrees existentes e mudanças recentes relevantes para a área da task antes de assumir que o contexto atual está livre ou inédito.
+4. Registrar a sessão atual em `/memories/repo/active-agent-sessions.md` antes de começar a editar arquivos, informando data, agente, branch, worktree, status e escopo.
+5. Atualizar `/memories/repo/recent-agent-changes.md` sempre que houver mudança relevante de escopo, blocker, handoff ou encerramento de sessão.
+
+**Escopo obrigatório da regra:** Este preflight deve permanecer alinhado entre `.github/copilot-instructions.md`, `AGENTS.md`, `.agent/workflows/parallel-development.md`, `.claude/CLAUDE.md`, `.gemini/GEMINI.md`, `context/GEMINI.md` e `.github/ANTIGRAVITY-AUTOMATION.md`.
+
 ## 📋 Checklist Obrigatório no INÍCIO de Cada Task/Chat
 
 ### 1. Criar Worktree + Branch a partir da demo-stable

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -5,6 +5,20 @@
 Todos os agentes e modelos que operam neste workspace DEVEM seguir obrigatoriamente as instruções contidas no arquivo mestre:
 `.github/copilot-instructions.md`
 
+## 🧠 Preflight de Memória Compartilhada (OBRIGATÓRIO)
+
+Antes de iniciar ou retomar qualquer task, todo agente DEVE executar o preflight de memória definido no arquivo mestre.
+
+Leitura mínima obrigatória dos últimos 30 dias:
+- `/memories/repo/shared-memory-preflight.md`
+- `/memories/repo/active-agent-sessions.md`
+- `/memories/repo/recent-agent-changes.md`
+- `/memories/repo/windows-worktree-notes.md`
+- `.coordination/queue.yaml`
+- `.coordination/ownership-map.yaml`
+
+Se houver risco de conflito, handoff recente ou dúvida sobre atividade paralela, consultar também `.coordination/master-events.ndjson` e o histórico recente da branch/área antes de editar arquivos.
+
 ## Protocolo Anti-Erros Reais (OBRIGATÓRIO)
 
 Estes guardrails foram adicionados após falhas reais em sweep/admin-plus e DEVEM ser seguidos por qualquer agente antes de assumir bug de aplicação:

--- a/context/GEMINI.md
+++ b/context/GEMINI.md
@@ -40,6 +40,18 @@ Eu sou programado para seguir estritamente as diretrizes definidas no arquivo `R
 
 **Regra:** Todo arquivo de código-fonte (`.ts`, `.tsx`) **deve** começar com um comentário em bloco (docblock) que explica de forma clara e concisa o propósito do arquivo.
 
+## 6.1 Preflight Obrigatório de Memória Compartilhada
+
+Antes de iniciar ou continuar qualquer implementação, alteração, correção ou investigação, agentes Gemini DEVEM revisar os **últimos 30 dias** de contexto compartilhado em:
+1. `/memories/repo/shared-memory-preflight.md`
+2. `/memories/repo/active-agent-sessions.md`
+3. `/memories/repo/recent-agent-changes.md`
+4. `/memories/repo/windows-worktree-notes.md`
+5. `.coordination/queue.yaml`
+6. `.coordination/ownership-map.yaml`
+
+Se houver handoff, atividade paralela ou conflito potencial, consultar também `.coordination/master-events.ndjson` e o histórico recente da branch/área. Antes de editar arquivos, o agente Gemini DEVE registrar sua sessão atual em `/memories/repo/active-agent-sessions.md`.
+
 ## 7. Estratégia de Testes e Segurança (MANDATÓRIO)
 
 A estratégia de testes segue o **Guia de Qualidade & Segurança de Código** (`context/QUALITY_SECURITY_WORKFLOW.md`).


### PR DESCRIPTION
## Summary
- enforce a mandatory shared-memory preflight before agents start or resume work
- align Copilot, AGENTS, workflow, Claude, Gemini, and Antigravity guidance
- document persistent repo memory files used for active sessions and recent changes

## Validation
- editor diagnostics on the modified documentation files returned no errors
- docs-only change; no runtime code paths changed

## Notes
- direct push to main was not used; repository policy requires PR-based promotion