### PR TITLE
fix: support Neon pooled and direct Postgres URLs

### DIFF
--- a/.github/workflows/deploy-hml-vercel.yml
+++ b/.github/workflows/deploy-hml-vercel.yml
@@ -35,7 +35,7 @@ on:
         type: boolean
 
 env:
-  PRISMA_SCHEMA: prisma-alternatives/schema.postgresql.prisma
+  PRISMA_SCHEMA: prisma-deploy/schema.postgresql.prisma
   VERCEL_ORG_ID: ${{ secrets.VERCEL_ORG_ID }}
   VERCEL_PROJECT_ID: ${{ secrets.VERCEL_PROJECT_ID }}
 
@@ -61,7 +61,7 @@ jobs:
         run: npm ci
 
       - name: ðŸ”„ Copy PostgreSQL schema
-        run: cp prisma-alternatives/schema.postgresql.prisma prisma/schema.prisma
+        run: cp prisma-deploy/schema.postgresql.prisma prisma/schema.prisma
 
       - name: ðŸ—„ï¸ Generate Prisma Client
         run: npx prisma generate
@@ -126,7 +126,7 @@ jobs:
         run: npm ci
 
       - name: ðŸ”„ Copy PostgreSQL schema
-        run: cp prisma-alternatives/schema.postgresql.prisma prisma/schema.prisma
+        run: cp prisma-deploy/schema.postgresql.prisma prisma/schema.prisma
 
       - name: ðŸ—„ï¸ Generate Prisma Client
         run: npx prisma generate
@@ -218,7 +218,7 @@ jobs:
         run: npx playwright install --with-deps chromium
 
       - name: ðŸ”„ Copy PostgreSQL schema
-        run: cp prisma-alternatives/schema.postgresql.prisma prisma/schema.prisma
+        run: cp prisma-deploy/schema.postgresql.prisma prisma/schema.prisma
 
       - name: ðŸ—„ï¸ Generate Prisma Client
         run: npx prisma generate

--- a/prisma-deploy/schema.postgresql.prisma
+++ b/prisma-deploy/schema.postgresql.prisma
@@ -1,14 +1,14 @@
 // =============================================================================
 // PRISMA SCHEMA - POSTGRESQL VERSION (Vercel / Demo Environment)
 // =============================================================================
-// Este schema ├® uma c├│pia do schema.prisma principal, com provider alterado
+// Este schema é uma cópia do schema.prisma principal, com provider alterado
 // para PostgreSQL. Deve ser mantido sincronizado com o schema MySQL.
 // 
-// USO: Este schema ├® usado automaticamente pelo workflow de deploy para Vercel
-//      atrav├®s do script prepare-vercel-demo.ps1 ou GitHub Action
+// USO: Este schema é usado automaticamente pelo workflow de deploy para Vercel
+//      através do script prepare-vercel-demo.ps1 ou GitHub Action
 //
 // NOTA: BigInt @default(autoincrement()), @db.Text, @db.Decimal, @db.VarChar
-//       s├úo todos compat├¡veis entre MySQL e PostgreSQL no Prisma.
+//       são todos compatíveis entre MySQL e PostgreSQL no Prisma.
 // =============================================================================
 
 generator client {
@@ -16,8 +16,13 @@ generator client {
 }
 
 datasource db {
-  provider = "postgresql"
-  url      = env("DATABASE_URL")
+  provider  = "postgresql"
+  // NEON: POSTGRES_PRISMA_URL is the pgbouncer-pooled URL for Prisma runtime.
+  // This variable is REQUIRED and injected by the Neon Vercel integration.
+  url       = env("POSTGRES_PRISMA_URL")
+  // NEON: POSTGRES_URL_NON_POOLING is the direct connection URL for Prisma CLI
+  // (prisma db push, prisma migrate). Also REQUIRED — injected by Neon integration.
+  directUrl = env("POSTGRES_URL_NON_POOLING")
 }
 
 model Asset {
@@ -32,7 +37,6 @@ model Asset {
   sellerId                   BigInt?
   evaluationValue            Decimal?                @db.Decimal(15, 2)
   imageUrl                   String?
-  CoverImage                 MediaItem?              @relation("AssetCoverImage", fields: [imageMediaId], references: [id])
   imageMediaId               BigInt?
   galleryImageUrls           Json?
   mediaItemIds               Json?
@@ -40,6 +44,7 @@ model Asset {
   locationCity               String?
   locationState              String?
   address                    String?
+  addressLink                String?                 @db.VarChar(500)
   latitude                   Decimal?
   longitude                  Decimal?
   lotId                      BigInt?
@@ -164,6 +169,7 @@ model Asset {
   Seller                     Seller?                 @relation(fields: [sellerId], references: [id])
   Subcategory                Subcategory?            @relation(fields: [subcategoryId], references: [id])
   Tenant                     Tenant                  @relation(fields: [tenantId], references: [id], onDelete: Cascade)
+  CoverImage                 MediaItem?              @relation("AssetCoverImage", fields: [imageMediaId], references: [id])
   AssetMedia                 AssetMedia[]
   AssetsOnLots               AssetsOnLots[]
 
@@ -238,6 +244,7 @@ model Auction {
 
   onlineUrl                String?                @db.VarChar(500)
   address                  String?
+  addressLink              String?                @db.VarChar(500)
   zipCode                  String?                @db.VarChar(10)
   latitude                 Decimal?               @db.Decimal(10, 8)
   longitude                Decimal?               @db.Decimal(11, 8)
@@ -273,7 +280,6 @@ model Auction {
   supportPhone             String?                @db.VarChar(50)
   supportEmail             String?                @db.VarChar(255)
   supportWhatsApp          String?                @db.VarChar(50)
-  CoverImage               MediaItem?             @relation("AuctionCoverImage", fields: [imageMediaId], references: [id])
   Auctioneer               Auctioneer?            @relation(fields: [auctioneerId], references: [id])
   LotCategory              LotCategory?           @relation(fields: [categoryId], references: [id])
   City                     City?                  @relation(fields: [cityId], references: [id])
@@ -283,6 +289,7 @@ model Auction {
   Seller                   Seller?                @relation(fields: [sellerId], references: [id])
   State                    State?                 @relation(fields: [stateId], references: [id])
   Tenant                   Tenant                 @relation(fields: [tenantId], references: [id])
+  CoverImage               MediaItem?             @relation("AuctionCoverImage", fields: [imageMediaId], references: [id])
   AuctionHabilitation      AuctionHabilitation[]
   AuctionStage             AuctionStage[]
   Bid                      Bid[]
@@ -351,6 +358,7 @@ model Auctioneer {
   supportWhatsApp    String?
   contactName        String?
   address            String?
+  addressLink        String?   @db.VarChar(500)
   city               String?
   state              String?
   zipCode            String?
@@ -390,7 +398,7 @@ model Bid {
   bidderDisplay   String?
   tenantId        BigInt
 
-  // V2 Monitor Preg├úo - Idempotency & Audit
+  // V2 Monitor Pregão - Idempotency & Audit
   idempotencyKey  String?    @db.VarChar(128)
   clientTimestamp  DateTime?
   ipAddress       String?    @db.VarChar(45)
@@ -419,7 +427,7 @@ model BiddingSettings {
   biddingInfoCheckIntervalSeconds Int?             @default(1)
   defaultStageDurationDays        Int?             @default(7)
   defaultDaysBetweenStages        Int?             @default(1)
-  // V2 Monitor Preg├úo
+  // V2 Monitor Pregão
   proxyBiddingEnabled             Boolean          @default(true)
   softCloseTriggerMinutes         Int              @default(3)
   PlatformSettings                PlatformSettings @relation(fields: [platformSettingsId], references: [id], onDelete: Cascade)
@@ -446,6 +454,7 @@ model ContactMessage {
   id        BigInt   @id @default(autoincrement())
   name      String
   email     String
+  phone     String?  @db.VarChar(30)
   subject   String?
   message   String   @db.Text
   isRead    Boolean  @default(false)
@@ -690,7 +699,6 @@ model Lot {
   discountPercentage       Int?
   additionalTriggers       Json?
   imageUrl                 String?              @db.Text
-  CoverImage               MediaItem?           @relation("LotCoverImage", fields: [imageMediaId], references: [id])
   imageMediaId             BigInt?
   galleryImageUrls         Json?
   mediaItemIds             Json?
@@ -720,11 +728,12 @@ model Lot {
   latitude                 Decimal?
   longitude                Decimal?
   mapAddress               String?
+  addressLink              String?              @db.VarChar(500)
   tenantId                 BigInt
   depositGuaranteeAmount   Decimal?             @db.Decimal(15, 2)
   depositGuaranteeInfo     String?              @db.Text
   requiresDepositGuarantee Boolean?             @default(false)
-  // V2 Monitor Preg├úo
+  // V2 Monitor Pregão
   reservePrice             Decimal?             @db.Decimal(15, 2)
   saleMode                 LotSaleMode          @default(LEILAO)
   AssetsOnLots             AssetsOnLots[]
@@ -740,6 +749,7 @@ model Lot {
   Subcategory              Subcategory?         @relation(fields: [subcategoryId], references: [id])
   Tenant                   Tenant               @relation(fields: [tenantId], references: [id], onDelete: Cascade)
   User                     User?                @relation(fields: [winnerId], references: [id])
+  CoverImage               MediaItem?           @relation("LotCoverImage", fields: [imageMediaId], references: [id])
   LotDocument              LotDocument[]
   LotQuestion              LotQuestion[]
   LotRisk                  LotRisk[]
@@ -1044,6 +1054,7 @@ model PlatformSettings {
   logoMediaId                BigInt?
   themeColorsDark            Json?
   themeColorsLight           Json?
+  featureFlags               Json?
   BiddingSettings            BiddingSettings?
   IdMasks                    IdMasks?
   MapSettings                MapSettings?
@@ -1072,7 +1083,7 @@ model RealtimeSettings {
   lawyerSubscriptionPrice   Int?
   lawyerPerUsePrice         Int?
   lawyerRevenueSharePercent Decimal?         @db.Decimal(5, 2)
-  // V2 Monitor Preg├úo - Admin Toggles
+  // V2 Monitor Pregão - Admin Toggles
   communicationStrategy     CommunicationStrategy @default(WEBSOCKET)
   videoStrategy             VideoStrategy         @default(DISABLED)
   idempotencyStrategy        IdempotencyStrategy   @default(SERVER_HASH)
@@ -1154,6 +1165,7 @@ model Seller {
   phone            String?           @db.Text
   contactName      String?
   address          String?           @db.Text
+  addressLink      String?           @db.VarChar(500)
   city             String?
   state            String?
   zipCode          String?
@@ -1916,7 +1928,7 @@ model WonLot {
 }
 
 // =============================================================================
-// ENUMS - Id├¬nticos ao schema MySQL (compat├¡veis entre ambos os bancos)
+// ENUMS - Idênticos ao schema MySQL (compatíveis entre ambos os bancos)
 // =============================================================================
 
 enum UserDocument_status {
@@ -2280,7 +2292,7 @@ enum Asset_occupationStatus {
   SHARED_POSSESSION
 }
 
-// V2 Monitor Preg├úo - New Enums
+// V2 Monitor Pregão - New Enums
 enum BidOrigin {
   MANUAL
   AUTO_BID
@@ -2310,7 +2322,7 @@ enum LotSaleMode {
   LANCE_CONDICIONAL
 }
 
-// V2 Monitor Preg├úo - Idempotency Log
+// V2 Monitor Pregão - Idempotency Log
 model BidIdempotencyLog {
   id              BigInt   @id @default(autoincrement())
   idempotencyKey  String   @db.VarChar(128)
@@ -2336,4 +2348,25 @@ model AuditConfig {
   createdAt DateTime @default(now())
 
   @@map("audit_configs")
+}
+
+// EMAIL LOG
+enum EmailStatus {
+  PENDING
+  SENT
+  FAILED
+}
+
+model EmailLog {
+  id               BigInt      @id @default(autoincrement())
+  recipient        String
+  subject          String
+  content          String      @db.Text
+  provider         String
+  status           EmailStatus @default(PENDING)
+  sentAt           DateTime?
+  errorMessage     String?     @db.Text
+  contactMessageId BigInt?
+  createdAt        DateTime    @default(now())
+  updatedAt        DateTime    @updatedAt
 }

--- a/src/lib/prisma.ts
+++ b/src/lib/prisma.ts
@@ -42,7 +42,7 @@ function isMySqlLikeUrl(url?: string): boolean {
 
 function validateDatabaseUrlProtocol(url?: string) {
   if (!url) {
-    throw new Error('[Prisma] DATABASE_URL não definida. Defina uma URL válida antes de iniciar a aplicação.');
+    throw new Error('[Prisma] Nenhuma URL de banco encontrada (POSTGRES_PRISMA_URL / DATABASE_URL). Defina uma URL válida antes de iniciar a aplicação.');
   }
 
   const hasValidProtocol = isPostgresLikeUrl(url) || isMySqlLikeUrl(url);
@@ -77,7 +77,9 @@ function validateDatabaseUrlProtocol(url?: string) {
  * Automaticamente usa Prisma Accelerate quando detectado pela DATABASE_URL.
  */
 function createPrismaClient(databaseUrl?: string) {
-  const effectiveUrl = databaseUrl || process.env.DATABASE_URL;
+  // POSTGRES_PRISMA_URL is injected by Neon Vercel Integration (pooled connection).
+  // DATABASE_URL is the legacy/generic fallback.
+  const effectiveUrl = databaseUrl || process.env.POSTGRES_PRISMA_URL || process.env.DATABASE_URL;
   validateDatabaseUrlProtocol(effectiveUrl);
   const useAccelerate = isPrismaAccelerateUrl(effectiveUrl);
   

--- a/src/lib/prisma/query-helpers.ts
+++ b/src/lib/prisma/query-helpers.ts
@@ -13,10 +13,10 @@
  */
 
 /**
- * Detecta o tipo de banco de dados a partir da DATABASE_URL
+ * Detecta o tipo de banco de dados a partir da DATABASE_URL ou POSTGRES_PRISMA_URL
  */
 export function getDatabaseType(): 'mysql' | 'postgresql' | 'unknown' {
-  const dbUrl = process.env.DATABASE_URL || '';
+  const dbUrl = process.env.POSTGRES_PRISMA_URL || process.env.DATABASE_URL || '';
   
   if (dbUrl.includes('mysql://')) {
     return 'mysql';
@@ -145,7 +145,7 @@ export function insensitiveEquals(value: string) {
  */
 export function logDatabaseType(): void {
   const dbType = getDatabaseType();
-  const dbUrl = process.env.DATABASE_URL || '';
+  const dbUrl = process.env.POSTGRES_PRISMA_URL || process.env.DATABASE_URL || '';
   
   // Oculta a senha na URL para log seguro
   const safeUrl = dbUrl.replace(/:([^:@]+)@/, ':****@');


### PR DESCRIPTION
## Summary
- switch deploy HML workflow and Prisma deploy schema to Neon pooled/direct URL variables
- update Prisma runtime helpers to prefer POSTGRES_PRISMA_URL with DATABASE_URL fallback
- keep Prisma deploy path aligned with current repository structure

## Validation
- npm run typecheck
- npx prisma validate --schema prisma-deploy/schema.postgresql.prisma
- npm run build
