### PR TITLE
fix: guard additionalTriggers with Array.isArray() to prevent runtime crash

### DIFF
--- a/src/components/cards/auction-card.tsx
+++ b/src/components/cards/auction-card.tsx
@@ -57,7 +57,7 @@ export default function AuctionCard({ auction, onUpdate }: AuctionCardProps) {
         triggers.push('DESTAQUE');
     }
 
-    if (auction.additionalTriggers) {
+    if (Array.isArray(auction.additionalTriggers)) {
         triggers.push(...auction.additionalTriggers);
     }
     

--- a/src/components/cards/auction-list-item.tsx
+++ b/src/components/cards/auction-list-item.tsx
@@ -54,7 +54,7 @@ export default function AuctionListItem({ auction, onUpdate, density = 'default'
         triggers.push('DESTAQUE');
     }
 
-    if (auction.additionalTriggers) {
+    if (Array.isArray(auction.additionalTriggers)) {
         triggers.push(...auction.additionalTriggers);
     }
     

--- a/src/components/cards/lot-card.tsx
+++ b/src/components/cards/lot-card.tsx
@@ -148,7 +148,7 @@ function LotCardClientContent({ lot, auction, badgeVisibilityConfig, platformSet
   }, [activeLotPrices, lot.evaluationValue, lot.discountPercentage]);
 
   const mentalTriggers = React.useMemo(() => {
-    const triggers = lot.additionalTriggers ? [...lot.additionalTriggers] : [];
+    const triggers = Array.isArray(lot.additionalTriggers) ? [...lot.additionalTriggers] : [];
     const settings = mentalTriggersGlobalSettings;
 
     if (sectionBadges.showPopularityBadge !== false && settings.showPopularityBadge && (lot.views || 0) > (settings.popularityViewThreshold || 500)) {

--- a/src/components/lot-preview-modal.tsx
+++ b/src/components/lot-preview-modal.tsx
@@ -75,7 +75,7 @@ export default function LotPreviewModal({ lot, auction, platformSettings, isOpen
 
 
   const mentalTriggers = useMemo(() => {
-    const triggers = lot.additionalTriggers ? [...lot.additionalTriggers] : [];
+    const triggers = Array.isArray(lot.additionalTriggers) ? [...lot.additionalTriggers] : [];
     const settings = mentalTriggersGlobalSettings;
 
     if (settings.showPopularityBadge && (lot.views || 0) > (settings.popularityViewThreshold || 500)) triggers.push('MAIS VISITADO');


### PR DESCRIPTION
## Hotfix: `TypeError: additionalTriggers is not iterable`

### Problema
A home page do deploy Vercel (demo-stable) estava crashando com:
```
TypeError: S.additionalTriggers is not iterable
```

### Causa Raiz
`additionalTriggers` é `Json?` no Prisma schema — pode ser `null`, `string`, `number`, `object` ou `array` em runtime. O TypeScript declara como `string[]`, mas o PostgreSQL JSONB pode retornar tipos não-iteráveis. 4 componentes usavam spread operator (`...`) assumindo que sempre seria array.

### Correção
Substituição de checks truthy (`if (x.additionalTriggers)`) por `Array.isArray()` em 4 componentes:
- `src/components/cards/auction-card.tsx`
- `src/components/cards/auction-list-item.tsx`
- `src/components/cards/lot-card.tsx`
- `src/components/lot-preview-modal.tsx`

### Impacto
- Zero risco de regressão (guard mais restritivo, não muda lógica)
- Resolve crash em 100% dos cenários onde `additionalTriggers` não é array