### PR TITLE
merge: promote demo-stable changes from last 3 days

### DIFF
--- a/context/REGRAS_NEGOCIO_CONSOLIDADO.md
+++ b/context/REGRAS_NEGOCIO_CONSOLIDADO.md
@@ -481,6 +481,42 @@ Proibir mix de `cuid()` em novos docs/código
 - Componente: `src/components/closing-soon-carousel.tsx`
 - Uso: `src/app/page.tsx`
 
+### RN-024A: Seção Paralela "Mais Lotes Ativos" na Home
+✅ **Preservação da Seção Principal**: A seção `homepage-featured-lots-section` DEVE permanecer inalterada como bloco primário da vitrine de lotes
+✅ **Fonte da Seção Paralela**: A seção `homepage-more-active-lots-section` DEVE usar apenas lotes com status `ABERTO_PARA_LANCES` que ainda nao foram renderizados na seção principal
+✅ **Limite e Ordenação**: A seção paralela DEVE exibir no maximo 8 cards, mantendo a ordem original recebida do pipeline de dados da home
+✅ **Nao Duplicação**: O mesmo lote NAO pode aparecer simultaneamente nas seções principal e paralela
+✅ **Renderização Condicional**: A seção paralela so deve aparecer quando existir ao menos 1 lote ativo adicional
+
+**Validações Obrigatórias**:
+1. `homepage-featured-lots-section` renderizada antes da seção paralela
+2. `homepage-more-active-lots-section` existe apenas quando houver lotes ativos restantes
+3. Grid da seção paralela limitado a 8 cards
+4. Interseção de lotes entre as duas seções deve ser vazia
+
+**BDD - Cenários de Teste**:
+- **Dado** que existem mais lotes ativos do que os exibidos na seção principal
+  **Quando** a home pública é carregada
+  **Então** a seção "Mais Lotes Ativos" deve ser exibida com os lotes restantes
+
+- **Dado** que um lote já foi exibido na seção principal
+  **Quando** a seção paralela é renderizada
+  **Então** esse lote não deve aparecer novamente na seção paralela
+
+- **Dado** que nao existem lotes ativos adicionais
+  **Quando** a home pública é carregada
+  **Então** a seção "Mais Lotes Ativos" não deve ser exibida
+
+**TDD - Cobertura Mínima Exigida**:
+- Teste unitário da regra de seleção de lotes restantes (`getMoreActiveLots`)
+- Teste E2E da homepage validando exibição condicional e ausência de duplicidade entre seções
+- Cenário BDD dedicado em `tests/itsm/features/home-more-active-lots.feature`
+
+**Implementação**:
+- Utilitário: `src/lib/home-lot-sections.ts`
+- Página cliente: `src/app/home-page-client.tsx`
+- Entrada de dados: `src/app/page.tsx`
+
 ### RN-025: Links Cruzados entre Entidades
 ✅ **Navegação Hierárquica**: Permitir navegação entre entidades relacionadas através de links diretos nas tabelas CRUD  
 ✅ **Relações Suportadas**:  
@@ -3675,6 +3711,9 @@ await page.goto(`${BASE_URL}/admin/auctions/${auctionId}/auction-control-center`
 | `auth-login-password` | Input de senha | Página de login |
 | `auction-dashboard-btn` | Botão "Leilões" | Sidebar do admin |
 | `super-opportunities-section` | Seção Super Oportunidades | Homepage pública |
+| `homepage-featured-lots-section` | Seção principal de lotes | Homepage pública |
+| `homepage-more-active-lots-section` | Seção paralela de lotes ativos | Homepage pública |
+| `homepage-more-active-lots-grid` | Grid de cards da seção paralela | Homepage pública |
 
 **Verificação de tabs no centro de controle:**
 ```typescript

--- a/src/app/home-page-client.tsx
+++ b/src/app/home-page-client.tsx
@@ -25,6 +25,7 @@ import { ptBR } from 'date-fns/locale';
 import { RadarOpportunityCard, RadarCalendar, RadarPreferencesModal } from '@/components/radar';
 import { useAuth } from '@/contexts/auth-context';
 import { useRouter } from 'next/navigation';
+import { getMoreActiveLots } from '@/lib/home-lot-sections';
 
 type HomeVariant = 'classic' | 'beta';
 
@@ -70,6 +71,12 @@ function HomeExperienceClassic({
     .sort((a, b) => new Date(b.createdAt || 0).getTime() - new Date(a.createdAt || 0).getTime())
     .slice(0, 8);
   const lotsToDisplay = featuredLots.length > 0 ? featuredLots : recentActiveLots;
+  const moreActiveLots = getMoreActiveLots({
+    allLots,
+    displayedLots: lotsToDisplay,
+    activeStatuses: activeLotStatuses,
+    limit: 8,
+  });
   const lotsTitle = featuredLots.length > 0 ? 'Lotes em Destaque' : 'Lotes Recentes';
 
   const featuredAuctions = allAuctions
@@ -190,6 +197,38 @@ function HomeExperienceClassic({
       </section>
 
       <FeaturedSellers sellers={featuredSellers} />
+
+      {/* Mais Lotes Ativos - lotes além dos já exibidos na seção de destaque */}
+      {moreActiveLots.length > 0 && (
+        <section className="section-more-active-lots" data-ai-id="homepage-more-active-lots-section">
+          <div className="wrapper-section-header" data-ai-id="homepage-more-active-lots-header">
+            <PublicSectionAdminTooltip
+              sectionId="homepage-more-active-lots"
+              description="Nesta seção exibimos lotes com status ABERTO_PARA_LANCES que não foram exibidos na seção de destaque acima, ampliando a visibilidade de mais oportunidades ativas."
+            >
+              <h2 className="header-section-title" data-ai-id="homepage-more-active-lots-title">Mais Lotes Ativos</h2>
+            </PublicSectionAdminTooltip>
+            <div className="wrapper-section-actions" data-ai-id="homepage-more-active-lots-actions">
+              <Button variant="outline" size="sm" asChild className="btn-view-all" data-ai-id="homepage-view-all-more-lots">
+                <Link href="/search?type=lots">
+                  Ver Todos <ArrowRight className="icon-arrow-right" />
+                </Link>
+              </Button>
+            </div>
+          </div>
+          <div className="grid-lots-grid-mode" data-ai-id="homepage-more-active-lots-grid">
+            {moreActiveLots.map(item => (
+              <BidExpertCard
+                key={item.id}
+                item={item}
+                type="lot"
+                platformSettings={platformSettings}
+                parentAuction={allAuctions.find(a => a.id === item.auctionId)}
+              />
+            ))}
+          </div>
+        </section>
+      )}
 
       <section className="section-browse-categories" data-ai-id="homepage-categories-section">
         <PublicSectionAdminTooltip

--- a/src/app/page.tsx
+++ b/src/app/page.tsx
@@ -48,7 +48,7 @@ export default async function HomePage({ searchParams }: { searchParams?: HomeSe
     ] = await Promise.allSettled([
             getPlatformSettings(),
             getAuctions(true, 10),
-            getLots(undefined, true, 12),
+            getLots(undefined, true, 20),
             getLotCategories(true),
             getSellers(true),
     ]);

--- a/src/lib/home-lot-sections.ts
+++ b/src/lib/home-lot-sections.ts
@@ -1,0 +1,31 @@
+/**
+ * @fileoverview Regras utilitarias para composicao de secoes de lotes na home.
+ */
+
+import type { Lot } from '@/types';
+
+interface GetMoreActiveLotsInput {
+  allLots: Lot[];
+  displayedLots: Lot[];
+  activeStatuses?: ReadonlyArray<Lot['status']>;
+  limit?: number;
+}
+
+const DEFAULT_ACTIVE_STATUSES: ReadonlyArray<Lot['status']> = ['ABERTO_PARA_LANCES'];
+
+export function getMoreActiveLots({
+  allLots,
+  displayedLots,
+  activeStatuses = DEFAULT_ACTIVE_STATUSES,
+  limit = 8,
+}: GetMoreActiveLotsInput): Lot[] {
+  if (limit <= 0) {
+    return [];
+  }
+
+  const displayedIds = new Set(displayedLots.map((lot) => lot.id));
+
+  return allLots
+    .filter((lot) => activeStatuses.includes(lot.status) && !displayedIds.has(lot.id))
+    .slice(0, limit);
+}

--- a/tests/e2e/home-section-order.spec.ts
+++ b/tests/e2e/home-section-order.spec.ts
@@ -1,10 +1,14 @@
+/**
+ * @fileoverview Valida ordem e consistencia das secoes principais de lotes na home publica.
+ */
+
 import { test, expect } from '@playwright/test';
+
+const BASE_URL = process.env.PLAYWRIGHT_TEST_BASE_URL || 'http://demo.localhost:9006';
 
 test.describe('Homepage Section Order', () => {
   test('should render categories carousel before featured lots', async ({ page }) => {
-    // Usar subdomínio demo para garantir dados do seed
-    // Aumentar timeout para dev mode (lazy compilation)
-    await page.goto('http://demo.localhost:9006/', { waitUntil: 'domcontentloaded', timeout: 120000 });
+    await page.goto(`${BASE_URL}/`, { waitUntil: 'domcontentloaded', timeout: 120000 });
 
     // Localizar as seções pelos data-ai-id
     const categoriesSection = page.locator('[data-ai-id="top-categories-section"]');
@@ -24,5 +28,45 @@ test.describe('Homepage Section Order', () => {
     } else {
       throw new Error('Could not calculate bounding boxes for sections');
     }
+  });
+
+  test('should render a non-overlapping more-active-lots section when additional active lots exist', async ({ page }) => {
+    await page.goto(`${BASE_URL}/`, { waitUntil: 'domcontentloaded', timeout: 120000 });
+
+    const featuredSection = page.locator('[data-ai-id="homepage-featured-lots-section"]');
+    await expect(featuredSection).toBeVisible();
+
+    const moreActiveLotsSection = page.locator('[data-ai-id="homepage-more-active-lots-section"]');
+    const hasMoreActiveLotsSection = await moreActiveLotsSection.isVisible().catch(() => false);
+
+    if (!hasMoreActiveLotsSection) {
+      test.skip(true, 'Sem lotes ativos adicionais no seed para renderizar a seção paralela.');
+      return;
+    }
+
+    await expect(moreActiveLotsSection).toBeVisible();
+
+    const featuredLotLinks = featuredSection.locator('[data-ai-id="lot-card-link-main"]');
+    const moreActiveLotLinks = moreActiveLotsSection.locator('[data-ai-id="lot-card-link-main"]');
+
+    await expect(moreActiveLotLinks.first()).toBeVisible();
+
+    const featuredHrefs = await featuredLotLinks.evaluateAll((elements) =>
+      elements
+        .map((element) => (element as HTMLAnchorElement).getAttribute('href'))
+        .filter((href): href is string => Boolean(href))
+    );
+
+    const moreActiveHrefs = await moreActiveLotLinks.evaluateAll((elements) =>
+      elements
+        .map((element) => (element as HTMLAnchorElement).getAttribute('href'))
+        .filter((href): href is string => Boolean(href))
+    );
+
+    expect(moreActiveHrefs.length).toBeGreaterThan(0);
+    expect(moreActiveHrefs.length).toBeLessThanOrEqual(8);
+
+    const overlappingHrefs = moreActiveHrefs.filter((href) => featuredHrefs.includes(href));
+    expect(overlappingHrefs).toEqual([]);
   });
 });

--- a/tests/itsm/features/home-more-active-lots.feature
+++ b/tests/itsm/features/home-more-active-lots.feature
@@ -1,0 +1,21 @@
+Funcionalidade: Secao paralela de lotes ativos na home
+  Como visitante da homepage
+  Eu quero ver uma segunda vitrine com lotes ativos nao repetidos
+  Para descobrir mais oportunidades alem dos lotes em destaque
+
+  Cenario: Exibir a secao Mais Lotes Ativos quando houver itens restantes
+    Dado que existem mais de 8 lotes com status ABERTO_PARA_LANCES
+    Quando eu acesso a homepage publica
+    Entao devo ver a secao "Mais Lotes Ativos"
+    E a secao deve conter no maximo 8 cards
+
+  Cenario: Nao repetir lotes entre as duas secoes de lotes
+    Dado que a homepage exibe a secao de lotes em destaque
+    E a homepage exibe a secao "Mais Lotes Ativos"
+    Quando eu comparo os links dos cards das duas secoes
+    Entao nao deve haver o mesmo lote nas duas secoes
+
+  Cenario: Ocultar a secao paralela quando nao houver lotes ativos adicionais
+    Dado que todos os lotes ativos ja estao na primeira secao de lotes
+    Quando eu acesso a homepage publica
+    Entao a secao "Mais Lotes Ativos" nao deve ser exibida

--- a/tests/unit/home-lot-sections.spec.ts
+++ b/tests/unit/home-lot-sections.spec.ts
@@ -1,0 +1,79 @@
+/**
+ * @fileoverview Testes unitarios para regras de composicao das secoes de lotes da home.
+ */
+
+import { describe, expect, it } from 'vitest';
+
+import type { Lot } from '@/types';
+import { getMoreActiveLots } from '@/lib/home-lot-sections';
+
+function createLot(id: string, status: Lot['status']): Lot {
+  return {
+    id,
+    auctionId: 'auction-1',
+    status,
+    title: `Lote ${id}`,
+  } as unknown as Lot;
+}
+
+describe('getMoreActiveLots', () => {
+  it('retorna apenas lotes ativos que nao estao na secao principal', () => {
+    const allLots = [
+      createLot('lot-1', 'ABERTO_PARA_LANCES'),
+      createLot('lot-2', 'ABERTO_PARA_LANCES'),
+      createLot('lot-3', 'ENCERRADO'),
+      createLot('lot-4', 'ABERTO_PARA_LANCES'),
+    ];
+
+    const displayedLots = [allLots[0], allLots[1]];
+
+    const result = getMoreActiveLots({
+      allLots,
+      displayedLots,
+      activeStatuses: ['ABERTO_PARA_LANCES'],
+      limit: 8,
+    });
+
+    expect(result.map((lot) => lot.id)).toEqual(['lot-4']);
+  });
+
+  it('respeita o limite maximo de retorno', () => {
+    const allLots = [
+      createLot('lot-1', 'ABERTO_PARA_LANCES'),
+      createLot('lot-2', 'ABERTO_PARA_LANCES'),
+      createLot('lot-3', 'ABERTO_PARA_LANCES'),
+    ];
+
+    const result = getMoreActiveLots({
+      allLots,
+      displayedLots: [],
+      activeStatuses: ['ABERTO_PARA_LANCES'],
+      limit: 2,
+    });
+
+    expect(result.map((lot) => lot.id)).toEqual(['lot-1', 'lot-2']);
+  });
+
+  it('retorna vazio quando o limite e zero ou negativo', () => {
+    const allLots = [createLot('lot-1', 'ABERTO_PARA_LANCES')];
+
+    expect(getMoreActiveLots({ allLots, displayedLots: [], limit: 0 })).toEqual([]);
+    expect(getMoreActiveLots({ allLots, displayedLots: [], limit: -1 })).toEqual([]);
+  });
+
+  it('retorna vazio quando nao existem lotes ativos restantes', () => {
+    const allLots = [
+      createLot('lot-1', 'ENCERRADO'),
+      createLot('lot-2', 'SUSPENSO'),
+    ];
+
+    const result = getMoreActiveLots({
+      allLots,
+      displayedLots: [],
+      activeStatuses: ['ABERTO_PARA_LANCES'],
+      limit: 8,
+    });
+
+    expect(result).toEqual([]);
+  });
+});


### PR DESCRIPTION
## Summary
- promote recent demo-stable merges to main
- includes auction audit remediation already merged in demo-stable
- includes home more-active-lots section merged via PR #551

## Smoke
- demo-stable preview: /api/health OK; homepage responds; debug lots exposed preview schema drift on Lot.addressLink
- main production: /api/health OK; /api/debug/lots OK before merge

## Notes
- no remaining functional commits from legacy PRs #507 and #509; only obsolete/test-artifact residue remained
