### PR TITLE
fix(admin-plus): corrigir CRUDs Mídias e Ativos/Bens

### DIFF
--- a/src/app/(adminplus)/admin-plus/assets/form.tsx
+++ b/src/app/(adminplus)/admin-plus/assets/form.tsx
@@ -39,10 +39,10 @@ export default function AssetForm({ open, onOpenChange, row, onSuccess }: Props)
   useEffect(() => {
     if (!open) return;
     Promise.all([
-      listLotCategories({ page: 1, pageSize: 500 }).then((r) => r.success && r.data ? (r.data as { data: { id: string; name: string }[] }).data.map((i) => ({ id: i.id, label: i.name })) : []),
-      listSubcategories({ page: 1, pageSize: 500 }).then((r) => r.success && r.data ? (r.data as { data: { id: string; name: string }[] }).data.map((i) => ({ id: i.id, label: i.name })) : []),
-      listSellers({ page: 1, pageSize: 500 }).then((r) => r.success && r.data ? (r.data as { data: { id: string; name: string }[] }).data.map((i) => ({ id: i.id, label: i.name })) : []),
-      listJudicialProcesses({ page: 1, pageSize: 500 }).then((r) => r.success && r.data ? (r.data as { data: { id: string; processNumber: string }[] }).data.map((i) => ({ id: i.id, label: i.processNumber })) : []),
+      listLotCategories({ page: 1, pageSize: 200 }).then((r) => r.success && r.data ? (r.data as { data: { id: string; name: string }[] }).data.map((i) => ({ id: i.id, label: i.name })) : []),
+      listSubcategories({ page: 1, pageSize: 200 }).then((r) => r.success && r.data ? (r.data as { data: { id: string; name: string }[] }).data.map((i) => ({ id: i.id, label: i.name })) : []),
+      listSellers({ page: 1, pageSize: 200 }).then((r) => r.success && r.data ? (r.data as { data: { id: string; name: string }[] }).data.map((i) => ({ id: i.id, label: i.name })) : []),
+      listJudicialProcesses({ page: 1, pageSize: 200 }).then((r) => r.success && r.data ? (r.data as { data: { id: string; processNumber: string }[] }).data.map((i) => ({ id: i.id, label: i.processNumber })) : []),
     ]).then(([c, s, se, jp]) => { setCategories(c); setSubcategories(s); setSellers(se); setProcesses(jp); });
     if (row) {
       form.reset({

--- a/src/app/(adminplus)/admin-plus/media-items/actions.ts
+++ b/src/app/(adminplus)/admin-plus/media-items/actions.ts
@@ -10,10 +10,10 @@ import { sanitizeResponse } from '@/lib/serialization-helper';
 import { mediaItemSchema } from './schema';
 import type { MediaItemRow } from './types';
 
-const includeUploader = { uploadedBy: { select: { name: true } } } as const;
+const includeUploader = { uploadedBy: { select: { fullName: true } } } as const;
 
 function toRow(item: Record<string, unknown>): MediaItemRow {
-  const i = item as Record<string, unknown> & { uploadedBy?: { name: string } | null };
+  const i = item as Record<string, unknown> & { uploadedBy?: { fullName: string | null } | null };
   return {
     id: String(i.id),
     fileName: String(i.fileName ?? ''),
@@ -29,7 +29,7 @@ function toRow(item: Record<string, unknown>): MediaItemRow {
     description: i.description ? String(i.description) : null,
     title: i.title ? String(i.title) : null,
     dataAiHint: i.dataAiHint ? String(i.dataAiHint) : null,
-    uploadedByUserName: i.uploadedBy?.name ?? null,
+    uploadedByUserName: i.uploadedBy?.fullName ?? null,
     tenantId: i.tenantId ? String(i.tenantId) : null,
     uploadedAt: i.uploadedAt instanceof Date ? i.uploadedAt.toISOString() : i.uploadedAt ? String(i.uploadedAt) : null,
   };


### PR DESCRIPTION
## Resumo\n\nCorrige os 2 últimos CRUDs quebrados do Admin Plus V2: **Mídias** e **Ativos/Bens**.\n\n## Alterações\n\n### 1. Mídias (`media-items/actions.ts`)\n\n**Problema:** `prisma.mediaItem.findMany()` falhava com `Unknown field 'name' for select statement on model User`.\n\n**Causa raiz:** O model `User` no Prisma tem o campo `fullName`, não `name`. O `includeUploader` selecionava `{ name: true }` que não existe.\n\n**Correção (3 pontos):**\n- `includeUploader` select: `{ name: true }` → `{ fullName: true }`\n- Type assertion: `{ name: string }` → `{ fullName: string | null }`\n- Row mapper: `i.uploadedBy?.name` → `i.uploadedBy?.fullName`\n\n### 2. Ativos/Bens (`assets/form.tsx`)\n\n**Problema:** Dropdowns de Categoria e Subcategoria no modal \"Novo Ativo\" abriam vazios, impedindo submissão.\n\n**Causa raiz:** O `Promise.all` de carregamento de FKs usava `pageSize: 500`, mas os schemas Zod de `listLotCategories` e `listSubcategories` impõem `z.number().max(200)`. O valor 500 falhava silenciosamente na validação Zod → `fieldErrors` retornado → dados não carregados.\n\n**Correção (4 pontos):**\n- `listLotCategories({ pageSize: 500 })` → `pageSize: 200`\n- `listSubcategories({ pageSize: 500 })` → `pageSize: 200`\n- `listSellers({ pageSize: 500 })` → `pageSize: 200`\n- `listJudicialProcesses({ pageSize: 500 })` → `pageSize: 200`\n\n## Testes\n\n- [x] `npm run typecheck` — 0 erros nos arquivos editados\n- [x] `npx next build` — build completo com sucesso\n- [x] CRUDs anteriormente funcionais (Leilões, Leiloeiros, Vendedores, Processos Judiciais, Categorias) não afetados\n\n## Contexto\n\nDos 7 CRUDs Admin Plus V2, 5 já funcionavam após fixes anteriores (safe-action.ts dispatch + handler arg swaps). Estes 2 eram os últimos pendentes.