### PR TITLE
fix(vercel): pin Prisma generate no vercel-build

### DIFF
--- a/scripts/vercel-build.mjs
+++ b/scripts/vercel-build.mjs
@@ -14,5 +14,5 @@ if (!process.env.POSTGRES_URL_NON_POOLING && process.env.POSTGRES_PRISMA_URL) {
 }
 
 cpSync('prisma-deploy/schema.postgresql.prisma', 'prisma/schema.prisma');
-execSync('npx prisma generate', { stdio: 'inherit' });
+execSync('npx prisma@5.22.0 generate', { stdio: 'inherit' });
 execSync('npm run build', { stdio: 'inherit' });


### PR DESCRIPTION
## Resumo\n- corrige scripts/vercel-build.mjs para usar 
px prisma@5.22.0 generate\n- completa o hotfix anterior (#682), removendo último ponto que ainda invocava Prisma 7 no deploy\n\n## Evidência\n- log de falha anterior mostrava erro em 
ode scripts/vercel-build.mjs -> 
px prisma generate com Prisma 7\n- após patch, cadeia de comandos de build fica consistente com Prisma 5.22.0