### PR TITLE
feat(search): Booking.com-style price range with histogram and auto-apply filters

### DIFF
--- a/src/app/search/page.tsx
+++ b/src/app/search/page.tsx
@@ -288,6 +288,88 @@ function SearchPageContent() {
     setIsFilterSheetOpen(false);
   };
 
+  const filteredWithoutPrice = useMemo(() => {
+    let itemsToFilter: any[] = [];
+    let itemTypeContext: 'auction' | 'lot' | 'direct_sale' = 'auction';
+
+    if (currentSearchType === 'auctions') {
+      itemsToFilter = allAuctions.filter(auc => auc.auctionType !== 'TOMADA_DE_PRECOS');
+      itemTypeContext = 'auction';
+    } else if (currentSearchType === 'lots') {
+      itemsToFilter = allLots;
+      itemTypeContext = 'lot';
+    } else if (currentSearchType === 'direct_sale') {
+      itemsToFilter = allDirectSales;
+      itemTypeContext = 'direct_sale';
+    } else if (currentSearchType === 'tomada_de_precos') {
+      itemsToFilter = allAuctions.filter(auc => auc.auctionType === 'TOMADA_DE_PRECOS');
+      itemTypeContext = 'auction';
+    }
+
+    let searchedItems = itemsToFilter;
+    if (searchTerm) {
+      const term = searchTerm.toLowerCase();
+      searchedItems = itemsToFilter.filter(item => {
+        let searchableText = item.title.toLowerCase();
+        if (item.description) searchableText += ` ${item.description.toLowerCase()}`;
+        if ('auctionName' in item && item.auctionName) searchableText += ` ${item.auctionName.toLowerCase()}`;
+        if ('sellerName' in item && item.sellerName) searchableText += ` ${item.sellerName.toLowerCase()}`;
+        else if ('seller' in item && (item as Auction).seller) searchableText += ` ${(item as Auction).seller!.name.toLowerCase()}`;
+        if ('id' in item && item.id) searchableText += ` ${String(item.id).toLowerCase()}`;
+        return searchableText.includes(term);
+      });
+    }
+
+    return searchedItems.filter(item => {
+      const itemEffectiveStatus = itemTypeContext === 'auction'
+        ? getEffectiveAuctionStatus(item as Auction) || item.status
+        : itemTypeContext === 'lot'
+          ? getEffectiveLotStatus(item as Lot, allAuctions.find(a => a.id === item.auctionId)) || item.status
+          : item.status;
+
+      if (activeFilters.category !== 'TODAS') {
+        const itemCategoryName = 'type' in item && item.type
+          ? item.type
+          : ('category' in item ? (item.category?.name || undefined) : undefined);
+        const category = allCategoriesForFilter.find(c => c.slug === activeFilters.category);
+        if (!itemCategoryName || !category || (item.categoryId !== category.id && slugify(itemCategoryName) !== category.slug)) return false;
+      }
+      // Note: priceRange filter intentionally OMITTED here — used for histogram bounds
+      if (activeFilters.locations.length > 0) {
+        const itemLocationString = ('locationCity' in item && 'locationState' in item && item.locationCity && item.locationState) ? `${item.locationCity} - ${item.locationState}` : ('city' in item && 'state' in item && item.city && item.state) ? `${item.city} - ${item.state}` : ('cityName' in item && 'stateUf' in item && item.cityName && item.stateUf) ? `${item.cityName} - ${item.stateUf}` : undefined;
+        if (!itemLocationString || !activeFilters.locations.includes(itemLocationString)) return false;
+      }
+      if (activeFilters.sellers.length > 0) {
+        let sellerName: string | undefined = undefined;
+        if ('sellerName' in item && item.sellerName) sellerName = item.sellerName;
+        else if ('seller' in item && (item as Auction).seller) sellerName = (item as Auction).seller!.name;
+        if (!sellerName || !activeFilters.sellers.includes(sellerName)) return false;
+      }
+      if (activeFilters.status && activeFilters.status.length > 0) {
+        if (!itemEffectiveStatus || !activeFilters.status.includes(itemEffectiveStatus as string)) return false;
+      }
+      if (itemTypeContext === 'auction' && activeFilters.modality !== 'TODAS' && (item as Auction).auctionType?.toUpperCase() !== activeFilters.modality) return false;
+      if (itemTypeContext === 'direct_sale' && activeFilters.offerType && activeFilters.offerType !== 'ALL' && (item as DirectSaleOffer).offerType !== activeFilters.offerType) return false;
+      if (itemTypeContext === 'auction' && activeFilters.praça && activeFilters.praça !== 'todas') {
+        const stagesCount = (item as Auction).auctionStages?.length || 0;
+        if (activeFilters.praça === 'unica' && stagesCount !== 1) return false;
+        if (activeFilters.praça === 'multiplas' && stagesCount <= 1) return false;
+      }
+      return true;
+    });
+  }, [searchTerm, activeFilters, currentSearchType, allAuctions, allLots, allDirectSales, allCategoriesForFilter]);
+
+  const pricePoints = useMemo(() => {
+    return filteredWithoutPrice
+      .map(item => {
+        const p = 'price' in item && typeof item.price === 'number' ? item.price
+                 : 'initialOffer' in item && typeof item.initialOffer === 'number' ? item.initialOffer
+                 : undefined;
+        return p;
+      })
+      .filter((p): p is number => p !== undefined && p > 0);
+  }, [filteredWithoutPrice]);
+
   const filteredAndSortedItems = useMemo(() => {
     let itemsToFilter: any[] = [];
     let itemTypeContext: 'auction' | 'lot' | 'direct_sale' = 'auction';
@@ -357,7 +439,7 @@ function SearchPageContent() {
       if (itemTypeContext === 'direct_sale' && activeFilters.offerType && activeFilters.offerType !== 'ALL' && (item as DirectSaleOffer).offerType !== activeFilters.offerType) return false;
 
       // Filtro de praças para leilões
-      if ((itemTypeContext === 'auction' || itemTypeContext === 'tomada_de_precos') && activeFilters.praça && activeFilters.praça !== 'todas') {
+      if (itemTypeContext === 'auction' && activeFilters.praça && activeFilters.praça !== 'todas') {
         const stagesCount = (item as Auction).auctionStages?.length || 0;
         if (activeFilters.praça === 'unica' && stagesCount !== 1) return false;
         if (activeFilters.praça === 'multiplas' && stagesCount <= 1) return false;
@@ -546,6 +628,8 @@ function SearchPageContent() {
             onFilterReset={handleFilterReset}
             initialFilters={activeFilters as ActiveFilters}
             filterContext={currentSearchType as 'auctions' | 'directSales' | 'lots' | 'tomada_de_precos'}
+            pricePoints={pricePoints}
+            autoApply={true}
           />
         </aside>
 

--- a/src/app/semantic-classes.css
+++ b/src/app/semantic-classes.css
@@ -346,6 +346,18 @@
   .wrapper-filter-price-display { @apply flex justify-between text-xs text-muted-foreground; }
   .text-filter-price-min { @apply inline; }
   .text-filter-price-max { @apply inline; }
+
+  /* Booking.com-style price range component */
+  .wrapper-filter-price-booking     { @apply pt-1 space-y-3; }
+  .wrapper-filter-price-inputs      { @apply flex gap-2; }
+  .wrapper-filter-price-input-group { @apply flex-1 space-y-1; }
+  .label-filter-price-input         { @apply text-xs text-muted-foreground font-medium; }
+  .wrapper-filter-price-input-field { @apply relative flex items-center; }
+  .prefix-filter-price-input        { @apply absolute left-2 text-xs text-muted-foreground pointer-events-none select-none; }
+  .input-filter-price-value         { @apply h-8 pl-7 text-sm; }
+  .wrapper-filter-price-histogram   { @apply flex items-end gap-px h-12 px-0.5; }
+  .bar-filter-price-histogram       { @apply flex-1 bg-muted rounded-sm min-h-[3px] transition-colors duration-150; }
+  .bar-filter-price-histogram--active { @apply bg-primary/60; }
   .content-filter-accordion-scroll { @apply space-y-2 max-h-60 overflow-y-auto pr-2 pb-3; }
   .content-filter-accordion-dates { @apply space-y-3 pt-1 pb-3; }
   .wrapper-filter-date-field { @apply space-y-1; }

--- a/src/components/BidExpertFilter.tsx
+++ b/src/components/BidExpertFilter.tsx
@@ -12,7 +12,7 @@ import { Slider } from '@/components/ui/slider';
 import { Calendar } from '@/components/ui/calendar';
 import { Popover, PopoverTrigger, PopoverContent } from '@/components/ui/popover';
 import { Filter, CalendarIcon, RefreshCw, ShoppingCart, MapPin } from 'lucide-react';
-import { useState, useEffect } from 'react';
+import { useState, useEffect, useMemo } from 'react';
 import { format } from 'date-fns';
 import { ptBR } from 'date-fns/locale';
 import type { LotCategory, DirectSaleOfferType, VehicleMake, VehicleModel } from '@/types';
@@ -46,8 +46,10 @@ interface BidExpertFilterProps {
   onFilterReset: () => void;
   initialFilters?: ActiveFilters;
   filterContext?: 'auctions' | 'directSales' | 'lots' | 'tomada_de_precos';
-  disableCategoryFilter?: boolean; // New prop to disable category selection
-  hideMapCTA?: boolean; // Hides the "Mostrar no mapa" banner (use when already on the map page)
+  disableCategoryFilter?: boolean;
+  hideMapCTA?: boolean;
+  pricePoints?: number[];
+  autoApply?: boolean;
 }
 
 const defaultModalities = [
@@ -85,6 +87,128 @@ const praçaOptions = [
 
 import { useRouter, useSearchParams } from 'next/navigation';
 
+// ---- PriceRangeBooking: Booking.com-style dual-handle slider with histogram ----
+interface PriceRangeBookingProps {
+  value: [number, number];
+  pricePoints: number[];
+  onChange: (value: [number, number]) => void;
+  onCommit: (value: [number, number]) => void;
+}
+
+function PriceRangeBooking({ value, pricePoints, onChange, onCommit }: PriceRangeBookingProps) {
+  const sliderMin = pricePoints.length > 0 ? Math.floor(Math.min(...pricePoints) / 1000) * 1000 : 0;
+  const sliderMax = pricePoints.length > 0 ? Math.ceil(Math.max(...pricePoints) / 1000) * 1000 : 1000000;
+
+  const [minInput, setMinInput] = useState(String(value[0]));
+  const [maxInput, setMaxInput] = useState(String(value[1]));
+  useEffect(() => { setMinInput(String(value[0])); }, [value[0]]);
+  useEffect(() => { setMaxInput(String(value[1])); }, [value[1]]);
+
+  const BARS = 20;
+  const histogramBars = useMemo(() => {
+    if (pricePoints.length === 0 || sliderMax === sliderMin) return Array(BARS).fill(1);
+    const binSize = (sliderMax - sliderMin) / BARS;
+    const bins = Array(BARS).fill(0);
+    pricePoints.forEach(p => {
+      const idx = Math.min(Math.floor((p - sliderMin) / binSize), BARS - 1);
+      if (idx >= 0) bins[idx]++;
+    });
+    return bins;
+  }, [pricePoints, sliderMin, sliderMax]);
+
+  const maxBinCount = Math.max(...histogramBars, 1);
+
+  const isBarActive = (i: number) => {
+    if (sliderMax === sliderMin) return true;
+    const binSize = (sliderMax - sliderMin) / BARS;
+    const barMin = sliderMin + i * binSize;
+    const barMax = sliderMin + (i + 1) * binSize;
+    return barMax >= value[0] && barMin <= value[1];
+  };
+
+  const commitMin = () => {
+    const parsed = parseInt(minInput.replace(/\D/g, ''), 10);
+    const newMin = isNaN(parsed) ? sliderMin : Math.max(sliderMin, Math.min(parsed, value[1] - 1000));
+    onChange([newMin, value[1]]);
+    onCommit([newMin, value[1]]);
+    setMinInput(String(newMin));
+  };
+
+  const commitMax = () => {
+    const parsed = parseInt(maxInput.replace(/\D/g, ''), 10);
+    const newMax = isNaN(parsed) ? sliderMax : Math.min(sliderMax, Math.max(parsed, value[0] + 1000));
+    onChange([value[0], newMax]);
+    onCommit([value[0], newMax]);
+    setMaxInput(String(newMax));
+  };
+
+  return (
+    <div className="wrapper-filter-price-booking" data-ai-id="filter-price-booking">
+      <div className="wrapper-filter-price-inputs">
+        <div className="wrapper-filter-price-input-group">
+          <label className="label-filter-price-input" htmlFor="filter-price-min-input">Mínimo</label>
+          <div className="wrapper-filter-price-input-field">
+            <span className="prefix-filter-price-input" aria-hidden="true">R$</span>
+            <Input
+              id="filter-price-min-input"
+              className="input-filter-price-value"
+              value={minInput}
+              onChange={e => setMinInput(e.target.value)}
+              onBlur={commitMin}
+              onKeyDown={e => e.key === 'Enter' && commitMin()}
+              inputMode="numeric"
+              aria-label="Preço mínimo"
+              data-ai-id="filter-price-min-input"
+            />
+          </div>
+        </div>
+        <div className="wrapper-filter-price-input-group">
+          <label className="label-filter-price-input" htmlFor="filter-price-max-input">Máximo</label>
+          <div className="wrapper-filter-price-input-field">
+            <span className="prefix-filter-price-input" aria-hidden="true">R$</span>
+            <Input
+              id="filter-price-max-input"
+              className="input-filter-price-value"
+              value={maxInput}
+              onChange={e => setMaxInput(e.target.value)}
+              onBlur={commitMax}
+              onKeyDown={e => e.key === 'Enter' && commitMax()}
+              inputMode="numeric"
+              aria-label="Preço máximo"
+              data-ai-id="filter-price-max-input"
+            />
+          </div>
+        </div>
+      </div>
+      {pricePoints.length > 0 && (
+        <div
+          className="wrapper-filter-price-histogram"
+          aria-hidden="true"
+          role="presentation"
+          data-ai-id="filter-price-histogram"
+        >
+          {histogramBars.map((count, i) => (
+            <div
+              key={i}
+              className={`bar-filter-price-histogram${isBarActive(i) ? ' bar-filter-price-histogram--active' : ''}`}
+              style={{ height: `${Math.max(8, Math.round((count / maxBinCount) * 100))}%` }}
+            />
+          ))}
+        </div>
+      )}
+      <Slider
+        min={sliderMin}
+        max={sliderMax || 1000000}
+        step={1000}
+        value={[Math.max(sliderMin, value[0]), Math.min(sliderMax || 1000000, value[1])]}
+        onValueChange={(v) => onChange(v as [number, number])}
+        onValueCommit={(v) => onCommit(v as [number, number])}
+        data-ai-id="filter-price-range-slider"
+      />
+    </div>
+  );
+}
+
 export default function BidExpertFilter({
   categories = [],
   locations = [],
@@ -98,8 +222,10 @@ export default function BidExpertFilter({
   onFilterReset,
   initialFilters,
   filterContext = 'auctions',
-  disableCategoryFilter = false, // Default to enabled
+  disableCategoryFilter = false,
   hideMapCTA = false,
+  pricePoints = [] as number[],
+  autoApply = false,
 }: BidExpertFilterProps) {
   const router = useRouter();
   const searchParams = useSearchParams();
@@ -142,42 +268,7 @@ export default function BidExpertFilter({
   }, [initialFilters, filterContext]);
 
 
-  const handleCategoryChange = (categorySlug: string) => {
-    setSelectedCategorySlug(categorySlug);
-  };
-
-  const handleLocationChange = (location: string) => {
-    setSelectedLocations(prev =>
-      prev.includes(location) ? prev.filter(l => l !== location) : [...prev, location]
-    );
-  };
-
-  const handleSellerChange = (seller: string) => {
-    setSelectedSellers(prev =>
-      prev.includes(seller) ? prev.filter(s => s !== seller) : [...prev, seller]
-    );
-  };
-
-  const handleMakeChange = (makeName: string) => {
-    setSelectedMakes(prev =>
-      prev.includes(makeName) ? prev.filter(m => m !== makeName) : [...prev, makeName]
-    );
-  };
-
-  const handleModelChange = (modelName: string) => {
-    setSelectedModels(prev =>
-      prev.includes(modelName) ? prev.filter(m => m !== modelName) : [...prev, modelName]
-    );
-  };
-
-
-  const handleStatusChange = (statusValue: string) => {
-    setSelectedStatus(prev =>
-      prev.includes(statusValue) ? prev.filter(s => s !== statusValue) : [...prev, statusValue]
-    );
-  };
-
-  const applyFilters = () => {
+  const applyFilters = (overrides?: Partial<ActiveFilters>) => {
     const currentFilters: ActiveFilters = {
       modality: selectedModality,
       category: selectedCategorySlug,
@@ -191,8 +282,69 @@ export default function BidExpertFilter({
       status: selectedStatus,
       offerType: filterContext === 'directSales' ? selectedOfferType : undefined,
       praça: selectedPraça,
+      ...overrides,
     };
     onFilterSubmit(currentFilters);
+  };
+
+  const handleCategoryChange = (categorySlug: string) => {
+    setSelectedCategorySlug(categorySlug);
+    if (autoApply) applyFilters({ category: categorySlug });
+  };
+
+  const handleModalityChange = (modality: string) => {
+    setSelectedModality(modality);
+    if (autoApply) applyFilters({ modality });
+  };
+
+  const handlePraçaChange = (praça: string) => {
+    setSelectedPraça(praça as 'todas' | 'unica' | 'multiplas');
+    if (autoApply) applyFilters({ praça: praça as 'todas' | 'unica' | 'multiplas' });
+  };
+
+  const handleOfferTypeChange = (offerType: string) => {
+    setSelectedOfferType(offerType as DirectSaleOfferType | 'ALL');
+    if (autoApply) applyFilters({ offerType: offerType as DirectSaleOfferType | 'ALL' });
+  };
+
+  const handleLocationChange = (location: string) => {
+    const newLocations = selectedLocations.includes(location)
+      ? selectedLocations.filter(l => l !== location)
+      : [...selectedLocations, location];
+    setSelectedLocations(newLocations);
+    if (autoApply) applyFilters({ locations: newLocations });
+  };
+
+  const handleSellerChange = (seller: string) => {
+    const newSellers = selectedSellers.includes(seller)
+      ? selectedSellers.filter(s => s !== seller)
+      : [...selectedSellers, seller];
+    setSelectedSellers(newSellers);
+    if (autoApply) applyFilters({ sellers: newSellers });
+  };
+
+  const handleMakeChange = (makeName: string) => {
+    const newMakes = selectedMakes.includes(makeName)
+      ? selectedMakes.filter(m => m !== makeName)
+      : [...selectedMakes, makeName];
+    setSelectedMakes(newMakes);
+    if (autoApply) applyFilters({ makes: newMakes });
+  };
+
+  const handleModelChange = (modelName: string) => {
+    const newModels = selectedModels.includes(modelName)
+      ? selectedModels.filter(m => m !== modelName)
+      : [...selectedModels, modelName];
+    setSelectedModels(newModels);
+    if (autoApply) applyFilters({ models: newModels });
+  };
+
+  const handleStatusChange = (statusValue: string) => {
+    const newStatus = selectedStatus.includes(statusValue)
+      ? selectedStatus.filter(s => s !== statusValue)
+      : [...selectedStatus, statusValue];
+    setSelectedStatus(newStatus);
+    if (autoApply) applyFilters({ status: newStatus });
   };
 
   const resetInternalFilters = () => {
@@ -210,7 +362,7 @@ export default function BidExpertFilter({
     setSelectedStatus(filterContext === 'directSales' ? ['ACTIVE'] : []);
     setSelectedOfferType('ALL');
     setSelectedPraça('todas');
-  }
+  };
 
   const handleResetFilters = () => {
     resetInternalFilters();
@@ -267,7 +419,7 @@ export default function BidExpertFilter({
           <AccordionItem value="modality" className="item-filter-accordion" data-ai-id="filter-modality-section">
             <AccordionTrigger className="trigger-filter-accordion">Modalidade do Leilão</AccordionTrigger>
             <AccordionContent className="content-filter-accordion">
-              <RadioGroup value={selectedModality} onValueChange={setSelectedModality} className="group-filter-radio" data-ai-id="filter-modality-group">
+              <RadioGroup value={selectedModality} onValueChange={handleModalityChange} className="group-filter-radio" data-ai-id="filter-modality-group">
                 {modalities.map(modal => (
                   <div key={modal.value} className="wrapper-filter-option" data-ai-id={`filter-modality-${modal.value}`}>
                     <RadioGroupItem value={modal.value} id={`mod-${modal.value}`} data-ai-id={`filter-modality-${modal.value}-radio`} />
@@ -283,7 +435,7 @@ export default function BidExpertFilter({
           <AccordionItem value="offerType" className="item-filter-accordion" data-ai-id="filter-offertype-section">
             <AccordionTrigger className="trigger-filter-accordion">Tipo de Oferta</AccordionTrigger>
             <AccordionContent className="content-filter-accordion">
-              <RadioGroup value={selectedOfferType} onValueChange={(value) => setSelectedOfferType(value as DirectSaleOfferType | 'ALL')} className="group-filter-radio" data-ai-id="filter-offertype-group">
+              <RadioGroup value={selectedOfferType} onValueChange={handleOfferTypeChange} className="group-filter-radio" data-ai-id="filter-offertype-group">
                 {offerTypes.map(type => (
                   <div key={type.value} className="wrapper-filter-option" data-ai-id={`filter-offertype-${type.value}`}>
                     <RadioGroupItem value={type.value} id={`offerType-${type.value}`} data-ai-id={`filter-offertype-${type.value}-radio`} />
@@ -321,7 +473,7 @@ export default function BidExpertFilter({
           <AccordionItem value="praça" className="item-filter-accordion" data-ai-id="filter-praca-section">
             <AccordionTrigger className="trigger-filter-accordion">Praças</AccordionTrigger>
             <AccordionContent className="content-filter-accordion">
-              <RadioGroup value={selectedPraça} onValueChange={(value) => setSelectedPraça(value as 'todas' | 'unica' | 'multiplas')} className="group-filter-radio" data-ai-id="filter-praca-group">
+              <RadioGroup value={selectedPraça} onValueChange={handlePraçaChange} className="group-filter-radio" data-ai-id="filter-praca-group">
                 {praçaOptions.map(option => (
                   <div key={option.value} className="wrapper-filter-option" data-ai-id={`filter-praca-${option.value}`}>
                     <RadioGroupItem value={option.value} id={`praça-${option.value}`} data-ai-id={`filter-praca-${option.value}-radio`} />
@@ -336,18 +488,12 @@ export default function BidExpertFilter({
         <AccordionItem value="price" className="item-filter-accordion" data-ai-id="filter-price-section">
           <AccordionTrigger className="trigger-filter-accordion">Faixa de Preço</AccordionTrigger>
           <AccordionContent className="content-filter-accordion-price">
-            <Slider
-              min={0}
-              max={1000000}
-              step={1000}
+            <PriceRangeBooking
               value={priceRange}
-              onValueChange={(value) => setPriceRange(value as [number, number])}
-              data-ai-id="filter-price-slider"
+              pricePoints={pricePoints}
+              onChange={(v) => setPriceRange(v)}
+              onCommit={(v) => { setPriceRange(v); applyFilters({ priceRange: v }); }}
             />
-            <div className="wrapper-filter-price-display" data-ai-id="filter-price-display">
-              <span className="text-filter-price-min" data-ai-id="filter-price-min-display">R$ {priceRange[0].toLocaleString('pt-BR')}</span>
-              <span className="text-filter-price-max" data-ai-id="filter-price-max-display">R$ {priceRange[1].toLocaleString('pt-BR')}</span>
-            </div>
           </AccordionContent>
         </AccordionItem>
 
@@ -475,7 +621,7 @@ export default function BidExpertFilter({
 
       </Accordion>
 
-      <Button className="btn-filter-apply" onClick={applyFilters} data-ai-id="bidexpert-filter-apply-btn">Aplicar Filtros</Button>
+      {!autoApply && <Button className="btn-filter-apply" onClick={() => applyFilters()} data-ai-id="bidexpert-filter-apply-btn">Aplicar Filtros</Button>}
     </aside>
   );
 }

--- a/src/components/ui/slider.tsx
+++ b/src/components/ui/slider.tsx
@@ -8,21 +8,31 @@ import { cn } from "@/lib/utils"
 const Slider = React.forwardRef<
   React.ElementRef<typeof SliderPrimitive.Root>,
   React.ComponentPropsWithoutRef<typeof SliderPrimitive.Root>
->(({ className, ...props }, ref) => (
-  <SliderPrimitive.Root
-    ref={ref}
-    className={cn(
-      "relative flex w-full touch-none select-none items-center",
-      className
-    )}
-    {...props}
-  >
-    <SliderPrimitive.Track className="relative h-2 w-full grow overflow-hidden rounded-full bg-secondary">
-      <SliderPrimitive.Range className="absolute h-full bg-primary" />
-    </SliderPrimitive.Track>
-    <SliderPrimitive.Thumb className="block h-5 w-5 rounded-full border-2 border-primary bg-background ring-offset-background transition-colors focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring focus-visible:ring-offset-2 disabled:pointer-events-none disabled:opacity-50" />
-  </SliderPrimitive.Root>
-))
+>(({ className, value, defaultValue, ...props }, ref) => {
+  const thumbCount = Math.max((value ?? defaultValue ?? [0]).length, 1);
+  return (
+    <SliderPrimitive.Root
+      ref={ref}
+      className={cn(
+        "relative flex w-full touch-none select-none items-center",
+        className
+      )}
+      value={value}
+      defaultValue={defaultValue}
+      {...props}
+    >
+      <SliderPrimitive.Track className="relative h-2 w-full grow overflow-hidden rounded-full bg-secondary">
+        <SliderPrimitive.Range className="absolute h-full bg-primary" />
+      </SliderPrimitive.Track>
+      {Array.from({ length: thumbCount }).map((_, i) => (
+        <SliderPrimitive.Thumb
+          key={i}
+          className="block h-5 w-5 rounded-full border-2 border-primary bg-background ring-offset-background transition-colors focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring focus-visible:ring-offset-2 disabled:pointer-events-none disabled:opacity-50"
+        />
+      ))}
+    </SliderPrimitive.Root>
+  );
+})
 Slider.displayName = SliderPrimitive.Root.displayName
 
 export { Slider }


### PR DESCRIPTION
## Summary

Replaces the simple price Slider with a Booking.com-inspired price range control and makes all filters auto-apply on every interaction.

## Changes

### `src/components/ui/slider.tsx`
- Dynamic N-thumb rendering via `.map()` to support dual-handle range sliders

### `src/app/semantic-classes.css`
- Added 11 Booking.com-style CSS utility classes: `wrapper-filter-price-booking`, `wrapper-filter-price-inputs`, `wrapper-filter-price-input-group`, `label-filter-price-input`, `wrapper-filter-price-input-field`, `prefix-filter-price-input`, `input-filter-price-value`, `wrapper-filter-price-histogram`, `bar-filter-price-histogram`, `bar-filter-price-histogram--active`

### `src/components/BidExpertFilter.tsx`
- Added `pricePoints?: number[]` and `autoApply?: boolean` props
- New `PriceRangeBooking` component: dual R$ text inputs + 20-bar histogram + dual-handle Slider
- `applyFilters()` now accepts `overrides?: Partial<ActiveFilters>` for instant per-field updates
- All filter handlers auto-call `applyFilters()` when `autoApply={true}`
- Apply button conditionally hidden when `autoApply={true}`

### `src/app/search/page.tsx`
- Added `filteredWithoutPrice` useMemo: same filter logic as `filteredAndSortedItems` but omits priceRange — used to compute dynamic histogram bounds
- Added `pricePoints` useMemo: extracts price/initialOffer values from `filteredWithoutPrice`
- Passes `pricePoints={pricePoints}` and `autoApply={true}` to `<BidExpertFilter>`
- Fixed pre-existing TS2367: `itemTypeContext` type cannot be `'tomada_de_precos'`

## UX Behavior
- Moving the slider updates results **immediately** (no button click needed)
- Histogram bars reflect price distribution of items matching all other active filters
- Min/max slider bounds update dynamically as other filters change
- Text inputs accept manual R$ entry, committed on blur or Enter key