### PR TITLE
fix(admin-plus): coerce page/pageSize in category/subcategory actions; filter stages by auctionId in lot-stage-prices form

### DIFF
--- a/src/app/(adminplus)/admin-plus/lot-categories/actions.ts
+++ b/src/app/(adminplus)/admin-plus/lot-categories/actions.ts
@@ -15,8 +15,8 @@ import type { PaginatedResponse } from '@/lib/admin-plus/types';
 /* ─── LIST ─── */
 export const listLotCategories = createAdminAction({
   inputSchema: z.object({
-    page: z.number().min(1).default(1),
-    pageSize: z.number().min(1).max(200).default(50),
+    page: z.coerce.number().min(1).default(1),
+    pageSize: z.coerce.number().min(1).max(200).default(50),
     search: z.string().optional(),
   }),
   requiredPermission: 'categories:read',

--- a/src/app/(adminplus)/admin-plus/lot-stage-prices/form.tsx
+++ b/src/app/(adminplus)/admin-plus/lot-stage-prices/form.tsx
@@ -33,7 +33,7 @@ interface Props {
 export default function LotStagePriceForm({ open, onOpenChange, editingRow, onSuccess }: Props) {
   const [lots, setLots] = useState<{ id: string; label: string }[]>([]);
   const [auctions, setAuctions] = useState<{ id: string; label: string }[]>([]);
-  const [stages, setStages] = useState<{ id: string; label: string }[]>([]);
+  const [stages, setStages] = useState<{ id: string; label: string; auctionId: string }[]>([]);
   const [loading, setLoading] = useState(false);
 
   const form = useForm<FormData>({ resolver: zodResolver(lotStagePriceSchema), defaultValues: { lotId: '', auctionId: '', auctionStageId: '', initialBid: '', bidIncrement: '' } });
@@ -44,7 +44,7 @@ export default function LotStagePriceForm({ open, onOpenChange, editingRow, onSu
     Promise.all([listLots({ page: 1, pageSize: 500 }), listAuctions({ page: 1, pageSize: 500 }), listAuctionStages({ page: 1, pageSize: 500 })]).then(([lr, ar, sr]) => {
       if (lr.success && lr.data) setLots((lr.data as any).data?.map((d: any) => ({ id: d.id, label: d.title || d.id })) ?? []);
       if (ar.success && ar.data) setAuctions((ar.data as any).data?.map((d: any) => ({ id: d.id, label: d.title || d.id })) ?? []);
-      if (sr.success && sr.data) setStages((sr.data as any).data?.map((d: any) => ({ id: d.id, label: d.name || d.title || d.id })) ?? []);
+      if (sr.success && sr.data) setStages((sr.data as any).data?.map((d: any) => ({ id: d.id, label: d.name || d.title || d.id, auctionId: d.auctionId ?? '' })) ?? []);
     });
   }, [open]);
 
@@ -84,7 +84,7 @@ export default function LotStagePriceForm({ open, onOpenChange, editingRow, onSu
           </div>
           <div className="space-y-2">
             <Label htmlFor="auctionId">Leilão *</Label>
-            <Select value={form.watch('auctionId')} onValueChange={v => form.setValue('auctionId', v)}>
+            <Select value={form.watch('auctionId')} onValueChange={v => { form.setValue('auctionId', v); form.setValue('auctionStageId', ''); }}>
               <SelectTrigger id="auctionId" data-ai-id="lot-stage-price-auctionId-select"><SelectValue placeholder="Selecione..." /></SelectTrigger>
               <SelectContent>{auctions.map(a => <SelectItem key={a.id} value={a.id}>{a.label}</SelectItem>)}</SelectContent>
             </Select>
@@ -94,7 +94,7 @@ export default function LotStagePriceForm({ open, onOpenChange, editingRow, onSu
             <Label htmlFor="auctionStageId">Praça *</Label>
             <Select value={form.watch('auctionStageId')} onValueChange={v => form.setValue('auctionStageId', v)}>
               <SelectTrigger id="auctionStageId" data-ai-id="lot-stage-price-stageId-select"><SelectValue placeholder="Selecione..." /></SelectTrigger>
-              <SelectContent>{stages.map(s => <SelectItem key={s.id} value={s.id}>{s.label}</SelectItem>)}</SelectContent>
+              <SelectContent>{stages.filter(s => !s.auctionId || s.auctionId === form.watch('auctionId')).map(s => <SelectItem key={s.id} value={s.id}>{s.label}</SelectItem>)}</SelectContent>
             </Select>
             {form.formState.errors.auctionStageId && <p className="text-sm text-destructive">{form.formState.errors.auctionStageId.message}</p>}
           </div>

--- a/src/app/(adminplus)/admin-plus/subcategories/actions.ts
+++ b/src/app/(adminplus)/admin-plus/subcategories/actions.ts
@@ -26,8 +26,8 @@ function toRow(record: Record<string, unknown>): SubcategoryRow {
 /* ─── LIST ─── */
 export const listSubcategories = createAdminAction({
   inputSchema: z.object({
-    page: z.number().min(1).default(1),
-    pageSize: z.number().min(1).max(200).default(50),
+    page: z.coerce.number().min(1).default(1),
+    pageSize: z.coerce.number().min(1).max(200).default(50),
     search: z.string().optional(),
   }),
   requiredPermission: 'subcategories:read',


### PR DESCRIPTION
## Resumo

Três patches cadastrais que nunca chegaram a `demo-stable` (existiam apenas no worktree local de uma sessão anterior):

### Patch 1 — `lot-categories/actions.ts`
- **Problema**: `z.number()` falha silenciosamente quando o client envia `page`/`pageSize` como strings serializadas
- **Fix**: `z.coerce.number()` nos campos `page` e `pageSize` do inputSchema de `listLotCategories`

### Patch 2 — `subcategories/actions.ts`
- **Problema**: Mesmo issue em `listSubcategories`
- **Fix**: `z.coerce.number()` nos campos `page` e `pageSize`

### Patch 3 — `lot-stage-prices/form.tsx`
- **Problema**: O dropdown de praças (AuctionStage) exibia ALL stages de TODOS os leilões — causava seleção errada quando múltiplos leilões tinham praças com nomes repetidos
- **Fix**:
  - Estado `stages` passa a incluir `auctionId: string`
  - Stages populadas com `d.auctionId ?? ''`
  - Select de praça filtra por `auctionId` selecionado: `stages.filter(s => !s.auctionId || s.auctionId === form.watch('auctionId'))`
  - Ao trocar o leilão (`onValueChange`), `auctionStageId` é limpo automaticamente

## Testes
- `npx tsc --noEmit` passa sem erros
- Playwright smoke a rodar contra porta 9007 (detalhes na sessão)

## Raiz do problema
Mudanças foram aplicadas num worktree efêmero (`bidexpert-test-cadastral-admin-cruds`) mas nunca commitadas antes do encerramento da sessão. Branch reutilizada depois para outra task (CI unit tests), sobrescrevendo o estado local.