### PR TITLE
fix(auctions): rewrite migrated legacy document URLs

### DIFF
--- a/src/lib/auctions/documents.ts
+++ b/src/lib/auctions/documents.ts
@@ -47,8 +47,15 @@ function resolveLegacyAuctionRoute(auction: AuctionDocumentsSource): string | nu
   return `/auctions/${routeId}`;
 }
 
-function normalizeLegacyPrimaryDocumentUrl(auction: AuctionDocumentsSource): string | null {
-  const normalizedUrl = normalizeDocumentUrl(auction?.documentsUrl);
+function rewriteLegacyDocumentUrl(value: unknown, auction: AuctionDocumentsSource): string | null {
+  if (typeof value === 'string') {
+    const trimmedValue = value.trim();
+    if (trimmedValue.startsWith('/')) {
+      return trimmedValue;
+    }
+  }
+
+  const normalizedUrl = normalizeDocumentUrl(value);
   if (!normalizedUrl) {
     return null;
   }
@@ -75,7 +82,7 @@ function buildLegacyAuctionDocuments(auction: AuctionDocumentsSource): AuctionPu
       key: 'documents',
       title: 'Edital e documentos do leilão',
       fileName: 'edital-leilao.pdf',
-      fileUrl: normalizeLegacyPrimaryDocumentUrl(auction),
+      fileUrl: rewriteLegacyDocumentUrl(auction?.documentsUrl, auction),
     },
     {
       key: 'evaluation-report',
@@ -119,12 +126,13 @@ export function getPublicAuctionDocuments(auction: AuctionDocumentsSource): Auct
       fileName: document.fileName,
       title: document.title,
       description: document.description ?? null,
-      fileUrl: document.fileUrl,
+      fileUrl: rewriteLegacyDocumentUrl(document.fileUrl, auction),
       fileSize: document.fileSize ?? null,
       mimeType: document.mimeType ?? null,
       displayOrder: document.displayOrder ?? 0,
       isPublic: document.isPublic,
     }))
+    .filter((document): document is AuctionPublicDocument => !!document.fileUrl)
     .sort((left, right) => (left.displayOrder ?? 0) - (right.displayOrder ?? 0));
 
   if (relationDocuments.length > 0) {

--- a/tests/unit/auction-documents.helper.spec.ts
+++ b/tests/unit/auction-documents.helper.spec.ts
@@ -13,6 +13,7 @@ import {
 describe('auction-documents helper', () => {
   it('returns sorted and public documents from normalized relation payload', () => {
     const documents = getPublicAuctionDocuments({
+      slug: 'auction-sp-equip-1773189171312',
       documents: [
         {
           id: 'doc-2',
@@ -36,7 +37,7 @@ describe('auction-documents helper', () => {
           fileName: 'edital.pdf',
           title: 'Edital',
           description: null,
-          fileUrl: 'https://cdn.bidexpert.com.br/docs/edital.pdf',
+          fileUrl: 'https://docs.bidexpert.com.br/auction/75',
           fileSize: 2000n,
           mimeType: 'application/pdf',
           displayOrder: 1,
@@ -63,6 +64,7 @@ describe('auction-documents helper', () => {
     });
 
     expect(documents.map((document) => document.id)).toEqual(['doc-1', 'doc-2']);
+    expect(documents[0]?.fileUrl).toBe('/auctions/auction-sp-equip-1773189171312');
     expect(getPrimaryAuctionDocument({ documents: documents as any })?.id).toBe('doc-1');
   });
 


### PR DESCRIPTION
## Summary
- remap migrated AuctionDocument file URLs that still target docs.bidexpert.com.br/auction/:id
- preserve canonical internal /auctions/:slug links once rewritten
- extend unit coverage for relation and fallback document rewrite scenarios

## Validation
- npm run typecheck
- npm run test:unit
- preview verification confirmed the bug before this hotfix and will be rechecked after deploy