### PR TITLE
fix(lotting): convert Cadastrar Novo Bem from Dialog to Sheet

### DIFF
--- a/src/app/admin/lots/lot-form.tsx
+++ b/src/app/admin/lots/lot-form.tsx
@@ -617,7 +617,7 @@ const LotForm = forwardRef<any, LotFormProps>(({
                         </div>
                         <Separator />
                         <div className="container-bens-disponiveis">
-                            <div className="header-bens-disponiveis"><h4 className="title-bens-disponiveis">Bens Disponíveis para Vincular</h4><div className="flex gap-2"><Button type="button" variant="secondary" size="sm" onClick={() => setIsAssetCreateModalOpen(true)} disabled={isAssetLinkingLocked}><PackagePlus className="mr-2 h-4 w-4"/>Cadastrar Novo Bem</Button><Button type="button" size="sm" onClick={handleLinkAssets} disabled={isAssetLinkingLocked || Object.keys(assetRowSelection).length === 0}><LinkIcon className="mr-2 h-4 w-4" /> Vincular Bem</Button></div></div>
+                            <div className="header-bens-disponiveis"><h4 className="title-bens-disponiveis">Bens Disponíveis para Vincular</h4><div className="flex gap-2"><Button type="button" variant="secondary" size="sm" onClick={() => setIsAssetCreateModalOpen(true)} disabled={isAssetLinkingLocked} data-ai-id="lot-form-cadastrar-novo-bem-button"><PackagePlus className="mr-2 h-4 w-4"/>Cadastrar Novo Bem</Button><Button type="button" size="sm" onClick={handleLinkAssets} disabled={isAssetLinkingLocked || Object.keys(assetRowSelection).length === 0} data-ai-id="lot-form-vincular-bem-button"><LinkIcon className="mr-2 h-4 w-4" /> Vincular Bem</Button></div></div>
                             {!isAssetLinkingLocked ? (
                               <DataTable columns={assetColumns} data={availableAssetsForTable} rowSelection={assetRowSelection} setRowSelection={setAssetRowSelection} searchPlaceholder="Buscar bem disponível..." searchColumnId="title" />
                             ) : (

--- a/src/components/admin/lotting/create-asset-modal.tsx
+++ b/src/components/admin/lotting/create-asset-modal.tsx
@@ -3,12 +3,12 @@
 
 import * as React from 'react';
 import {
-  Dialog,
-  DialogContent,
-  DialogHeader,
-  DialogTitle,
-  DialogDescription,
-} from '@/components/ui/dialog';
+  Sheet,
+  SheetContent,
+  SheetHeader,
+  SheetTitle,
+  SheetDescription,
+} from '@/components/ui/sheet';
 import { AssetFormV2 } from '@/app/admin/assets/asset-form-v2';
 import type { AssetFormData } from '@/app/admin/assets/asset-form-schema';
 import { createAsset } from '@/app/admin/assets/actions';
@@ -81,8 +81,18 @@ export default function CreateAssetModal({
   };
 
   return (
-    <Dialog open={isOpen} onOpenChange={onClose}>
-      <DialogContent className="max-w-4xl max-h-[90vh] overflow-y-auto">
+    <Sheet open={isOpen} onOpenChange={(open) => { if (!open) onClose(); }}>
+      <SheetContent
+        side="right"
+        className="w-full sm:max-w-2xl lg:max-w-4xl overflow-y-auto p-0"
+        data-ai-id="lot-form-create-asset-sheet"
+      >
+        <SheetHeader className="sr-only">
+          <SheetTitle>Cadastrar Novo Bem</SheetTitle>
+          <SheetDescription>
+            Cadastre um bem que ficará imediatamente disponível para loteamento.
+          </SheetDescription>
+        </SheetHeader>
         {isLoading ? (
             <div className="flex items-center justify-center p-8">
                 <Loader2 className="h-8 w-8 animate-spin" />
@@ -106,7 +116,7 @@ export default function CreateAssetModal({
               description="Cadastre um bem que ficará imediatamente disponível para loteamento."
             />
         )}
-      </DialogContent>
-    </Dialog>
+      </SheetContent>
+    </Sheet>
   );
 }


### PR DESCRIPTION
## Resumo

Correção do botão **Cadastrar Novo Bem** na tela de edição de lote (/admin/lots/[id]/edit).

## Problema reportado pelo usuário

> "O botão Cadastrar Bem não está funcionando, o correto é abrir o form de cadastro (formato sheet) para cadastro."

## Causa raiz

O componente `CreateAssetModal` (`src/components/admin/lotting/create-asset-modal.tsx`) usa o componente ShadCN `Dialog` (modal centralizado), divergindo do padrão admin-plus que usa `Sheet` (painel lateral).

## Correção

- Substitui `Dialog/DialogContent/DialogHeader/...` por `Sheet/SheetContent/SheetHeader/...`
- `SheetContent side='right'` com largura responsiva (`w-full sm:max-w-2xl lg:max-w-4xl`)
- `SheetHeader` em `sr-only` (acessibilidade) porque `AssetFormV2` ja renderiza seu proprio cabecalho
- Adiciona `data-ai-id` em **Cadastrar Novo Bem** e **Vincular Bem** para testabilidade

## Arquivos alterados

- `src/components/admin/lotting/create-asset-modal.tsx`
- `src/app/admin/lots/lot-form.tsx` (apenas data-ai-id)

## Validacao

- typecheck no arquivo alterado: sem erros novos
- `get_errors` em ambos arquivos: sem erros
- Padrao espelhado de `src/app/(adminplus)/admin-plus/assets/form.tsx`

## Pos-merge

Validacao em `https://demo.bidexpert.com.br/admin/lots/LOTE-0028/edit` apos deploy Vercel.
