### PR TITLE
Expand judicial process selector grid

### DIFF
--- a/.github/skills/admin-auction-wizard-integrity/SKILL.md
+++ b/.github/skills/admin-auction-wizard-integrity/SKILL.md
@@ -20,6 +20,7 @@ Evitar regressões estruturais no wizard e no cadastro administrativo de leilõe
 1. **Selectors primeiro, telas depois**
    - Antes de patch em uma tela específica, inspecione `src/components/ui/entity-selector.tsx` e `src/components/ui/data-table.tsx`.
    - Se o problema for comum a processo/categoria/comitente/leiloeiro, corrija a API compartilhada.
+   - O selector de `Processo Judicial` deve reutilizar uma configuração compartilhada de colunas e options; é proibido manter grids locais divergentes entre wizard e formulários administrativos.
 
 2. **Processo judicial e comitente são cadeia única**
    - Em fluxo judicial, o processo selecionado DEVE propagar `judicialProcessId` e o comitente resolvido até o formulário do leilão, review e persistência.
@@ -52,6 +53,7 @@ Evitar regressões estruturais no wizard e no cadastro administrativo de leilõe
 ## Checklist mínimo
 
 - [ ] O root cause está em tela específica ou no selector compartilhado?
+- [ ] O grid judicial exibe as colunas mínimas compartilhadas (processo, comitente, vara, comarca, tribunal, partes, matrícula/registro, ação/CNJ, bens e lotes)?
 - [ ] `judicialProcessId` e `sellerId` chegam ao estado final do wizard?
 - [ ] Existe etapa condicional quando o processo não resolve comitente?
 - [ ] O review final bate com o payload persistido?

--- a/context/REGRAS_NEGOCIO_CONSOLIDADO.md
+++ b/context/REGRAS_NEGOCIO_CONSOLIDADO.md
@@ -222,6 +222,13 @@ Schemas Zod + `react-hook-form` em todos formulários
 ✅ O comportamento legado de listar todos os ativos só é permitido enquanto nenhum ativo tiver sido rastreado na sessão atual.
 ✅ Testes E2E do wizard DEVEM selecionar ativos e processos por identidade determinística (título/número exato), nunca pela primeira linha disponível na listagem.
 
+### RN-010B: Grid compartilhado de Processo Judicial
+✅ Todo modal compartilhado de seleção de `Processo Judicial` DEVE usar a mesma configuração de colunas, sem duplicar grids locais por tela.
+✅ O grid precisa expor, no mínimo: número do processo, comitente, vara, comarca, tribunal, partes, indicador eletrônico, matrícula, registro, tipo de ação, código CNJ, descrição da ação, `Public ID`, datas de criação/atualização, quantidade de bens e quantidade de lotes.
+✅ As colunas `Bens` e `Lotes` são obrigatórias e não podem ser removidas do grid judicial.
+✅ A busca textual do modal deve considerar todas as propriedades exibidas no grid, para permitir distinção determinística entre processos parecidos.
+✅ A regra vale para qualquer superfície administrativa que reutilize o seletor judicial, inclusive wizard e formulário administrativo de leilão.
+
 **RCA / prevenção:** A regressão de lotes duplicados no fluxo de cadastro ocorreu porque o Step 4 listava todos os ativos disponíveis do tenant/comitente após cada recarga de dados, e o Playwright marcava todos os checkboxes visíveis. Isso contaminava a sessão com ativos antigos e fazia o total preparado crescer a cada execução.
 
 **Cenário BDD - Refetch não mistura ativos históricos**

--- a/src/app/admin/auctions/auction-form.tsx
+++ b/src/app/admin/auctions/auction-form.tsx
@@ -44,7 +44,10 @@ import { getLotCategories } from '../categories/actions';
 import { ChangeHistoryTab } from '@/components/audit/change-history-tab';
 import { ParticipantCard, type ParticipantCardData } from '@/components/admin/participant-card';
 import { AuctionDocumentsField } from '@/components/admin/auctions/auction-documents-field';
-import type { ColumnDef } from '@tanstack/react-table';
+import {
+  buildJudicialProcessSelectorOptions,
+  judicialProcessSelectorColumns,
+} from '@/components/admin/judicial-processes/judicial-process-selector-config';
 import { formatPhone } from '@/lib/format';
 
 const auctionStatusOptions = [
@@ -207,39 +210,7 @@ const renderSectionContent = (
       return (
         <div className="space-y-6">
           {(() => {
-            const judicialProcessDisplayColumns: ColumnDef<any>[] = [
-              {
-                accessorKey: 'processNumber',
-                header: 'Processo',
-                cell: ({ row }) => <div className="min-w-[180px] font-medium">{row.original.processNumber}</div>,
-              },
-              {
-                id: 'branch',
-                header: 'Vara / Comarca',
-                cell: ({ row }) => (
-                  <div className="min-w-[220px] text-sm">
-                    <div className="font-medium">{row.original.branchName || 'Vara não informada'}</div>
-                    <div className="text-muted-foreground">{row.original.districtName || 'Comarca não informada'}</div>
-                  </div>
-                ),
-              },
-              {
-                id: 'seller',
-                header: 'Comitente',
-                cell: ({ row }) => <div className="min-w-[180px] text-sm">{row.original.sellerName || 'Sem comitente vinculado'}</div>,
-              },
-              {
-                id: 'inventory',
-                header: 'Inventário',
-                cell: ({ row }) => (
-                  <div className="min-w-[120px] text-sm text-muted-foreground">
-                    {row.original.assetCount || 0} ativos
-                    <br />
-                    {row.original.lotCount || 0} lotes
-                  </div>
-                ),
-              },
-            ];
+            const judicialProcessOptions = buildJudicialProcessSelectorOptions(initialJudicialProcesses || []);
 
             return (
           <div className="grid grid-cols-1 md:grid-cols-3 gap-4">
@@ -279,25 +250,17 @@ const renderSectionContent = (
               <FormItem>
                 <FormLabel>Processo Judicial (Opcional)</FormLabel>
                 <EntitySelector
+                  entityName="Processo Judicial"
                   value={field.value}
                   onChange={field.onChange}
-                  options={(initialJudicialProcesses || []).map((p) => ({
-                    value: p.id,
-                    label: p.processNumber,
-                    processNumber: p.processNumber,
-                    branchName: p.branchName,
-                    districtName: p.districtName,
-                    sellerName: p.sellerName,
-                    assetCount: p.assetCount,
-                    lotCount: p.lotCount,
-                  }))}
+                  options={judicialProcessOptions}
                   placeholder="Vincule a um processo"
-                  searchPlaceholder="Buscar processo, vara, comarca ou comitente..."
+                  searchPlaceholder="Buscar processo, comitente, vara, comarca, tribunal, partes, matrícula, registro ou CNJ..."
                   emptyStateMessage="Nenhum processo."
                   onRefetch={handleRefetchProcesses}
                   isFetching={isSubmitting}
-                  displayColumns={judicialProcessDisplayColumns}
-                  dialogDescription="Selecione o processo judicial correto. O comitente será sincronizado automaticamente quando o processo possuir vínculo válido."
+                  displayColumns={judicialProcessSelectorColumns}
+                  dialogDescription="Selecione o processo judicial correto. O grid mostra número, comitente, vara, comarca, tribunal, partes, dados cadastrais do processo e os totais de bens/lotes para evitar seleção ambígua."
                 />
                 <FormDescription>Para bens de origem judicial.</FormDescription>
                 <FormMessage />

--- a/src/components/admin/judicial-processes/judicial-process-selector-config.tsx
+++ b/src/components/admin/judicial-processes/judicial-process-selector-config.tsx
@@ -1,0 +1,186 @@
+/**
+ * @fileoverview Configuração compartilhada do grid/modal de seleção de Processo Judicial.
+ */
+
+import type { JudicialProcess } from '@/types';
+import type { ColumnDef } from '@tanstack/react-table';
+
+const dateTimeFormatter = new Intl.DateTimeFormat('pt-BR', {
+  dateStyle: 'short',
+  timeStyle: 'short',
+});
+
+function formatDateTime(value?: string | Date | null): string {
+  if (!value) {
+    return '—';
+  }
+
+  const parsed = value instanceof Date ? value : new Date(value);
+  if (Number.isNaN(parsed.getTime())) {
+    return '—';
+  }
+
+  return dateTimeFormatter.format(parsed);
+}
+
+function formatEnumLabel(value?: string | null): string {
+  if (!value) {
+    return '—';
+  }
+
+  return value
+    .split('_')
+    .filter(Boolean)
+    .map((token) => token.charAt(0) + token.slice(1).toLowerCase())
+    .join(' ');
+}
+
+function formatParties(process: JudicialProcess): string {
+  if (!process.parties?.length) {
+    return '—';
+  }
+
+  return process.parties
+    .map((party) => `${formatEnumLabel(party.partyType)}: ${party.name}`)
+    .join(' | ');
+}
+
+function formatCount(value?: number | null): number {
+  return typeof value === 'number' && Number.isFinite(value) ? value : 0;
+}
+
+export type JudicialProcessSelectorOption = {
+  value: string;
+  label: string;
+  publicId: string;
+  processNumber: string;
+  sellerName: string;
+  branchName: string;
+  districtName: string;
+  courtName: string;
+  partiesSummary: string;
+  isElectronicLabel: string;
+  propertyMatricula: string;
+  propertyRegistrationNumber: string;
+  actionTypeLabel: string;
+  actionDescription: string;
+  actionCnjCode: string;
+  assetCount: number;
+  lotCount: number;
+  createdAtLabel: string;
+  updatedAtLabel: string;
+};
+
+export function buildJudicialProcessSelectorOptions(
+  processes: JudicialProcess[],
+): JudicialProcessSelectorOption[] {
+  return processes.map((process) => ({
+    value: process.id,
+    label: process.processNumber,
+    publicId: process.publicId,
+    processNumber: process.processNumber,
+    sellerName: process.sellerName || 'Sem comitente vinculado',
+    branchName: process.branchName || 'Vara não informada',
+    districtName: process.districtName || 'Comarca não informada',
+    courtName: process.courtName || 'Tribunal não informado',
+    partiesSummary: formatParties(process),
+    isElectronicLabel: process.isElectronic ? 'Sim' : 'Não',
+    propertyMatricula: process.propertyMatricula || '—',
+    propertyRegistrationNumber: process.propertyRegistrationNumber || '—',
+    actionTypeLabel: formatEnumLabel(process.actionType),
+    actionDescription: process.actionDescription || '—',
+    actionCnjCode: process.actionCnjCode || '—',
+    assetCount: formatCount(process.assetCount),
+    lotCount: formatCount(process.lotCount),
+    createdAtLabel: formatDateTime(process.createdAt),
+    updatedAtLabel: formatDateTime(process.updatedAt),
+  }));
+}
+
+export const judicialProcessSelectorColumns: ColumnDef<JudicialProcessSelectorOption>[] = [
+  {
+    accessorKey: 'processNumber',
+    header: () => <span data-ai-id="judicial-process-selector-header-process-number">Processo</span>,
+    cell: ({ row }) => <div className="min-w-[220px] font-medium">{row.original.processNumber}</div>,
+  },
+  {
+    accessorKey: 'sellerName',
+    header: () => <span data-ai-id="judicial-process-selector-header-seller">Comitente</span>,
+    cell: ({ row }) => <div className="min-w-[220px] text-sm">{row.original.sellerName}</div>,
+  },
+  {
+    accessorKey: 'branchName',
+    header: () => <span data-ai-id="judicial-process-selector-header-branch">Vara</span>,
+    cell: ({ row }) => <div className="min-w-[220px] text-sm">{row.original.branchName}</div>,
+  },
+  {
+    accessorKey: 'districtName',
+    header: () => <span data-ai-id="judicial-process-selector-header-district">Comarca</span>,
+    cell: ({ row }) => <div className="min-w-[180px] text-sm">{row.original.districtName}</div>,
+  },
+  {
+    accessorKey: 'courtName',
+    header: () => <span data-ai-id="judicial-process-selector-header-court">Tribunal</span>,
+    cell: ({ row }) => <div className="min-w-[220px] text-sm">{row.original.courtName}</div>,
+  },
+  {
+    accessorKey: 'partiesSummary',
+    header: () => <span data-ai-id="judicial-process-selector-header-parties">Partes</span>,
+    cell: ({ row }) => <div className="min-w-[260px] text-sm">{row.original.partiesSummary}</div>,
+  },
+  {
+    accessorKey: 'isElectronicLabel',
+    header: () => <span data-ai-id="judicial-process-selector-header-electronic">Eletrônico</span>,
+    cell: ({ row }) => <div className="min-w-[110px] text-sm">{row.original.isElectronicLabel}</div>,
+  },
+  {
+    accessorKey: 'propertyMatricula',
+    header: () => <span data-ai-id="judicial-process-selector-header-matricula">Matrícula</span>,
+    cell: ({ row }) => <div className="min-w-[160px] text-sm">{row.original.propertyMatricula}</div>,
+  },
+  {
+    accessorKey: 'propertyRegistrationNumber',
+    header: () => <span data-ai-id="judicial-process-selector-header-registration">Registro</span>,
+    cell: ({ row }) => <div className="min-w-[160px] text-sm">{row.original.propertyRegistrationNumber}</div>,
+  },
+  {
+    accessorKey: 'actionTypeLabel',
+    header: () => <span data-ai-id="judicial-process-selector-header-action-type">Tipo de ação</span>,
+    cell: ({ row }) => <div className="min-w-[180px] text-sm">{row.original.actionTypeLabel}</div>,
+  },
+  {
+    accessorKey: 'actionCnjCode',
+    header: () => <span data-ai-id="judicial-process-selector-header-cnj">Cód. CNJ</span>,
+    cell: ({ row }) => <div className="min-w-[130px] text-sm">{row.original.actionCnjCode}</div>,
+  },
+  {
+    accessorKey: 'actionDescription',
+    header: () => <span data-ai-id="judicial-process-selector-header-action-description">Descrição da ação</span>,
+    cell: ({ row }) => <div className="min-w-[260px] text-sm">{row.original.actionDescription}</div>,
+  },
+  {
+    accessorKey: 'assetCount',
+    header: () => <span data-ai-id="judicial-process-selector-header-assets">Bens</span>,
+    cell: ({ row }) => <div className="min-w-[90px] text-sm">{row.original.assetCount}</div>,
+  },
+  {
+    accessorKey: 'lotCount',
+    header: () => <span data-ai-id="judicial-process-selector-header-lots">Lotes</span>,
+    cell: ({ row }) => <div className="min-w-[90px] text-sm">{row.original.lotCount}</div>,
+  },
+  {
+    accessorKey: 'publicId',
+    header: () => <span data-ai-id="judicial-process-selector-header-public-id">Public ID</span>,
+    cell: ({ row }) => <div className="min-w-[160px] text-sm">{row.original.publicId}</div>,
+  },
+  {
+    accessorKey: 'createdAtLabel',
+    header: () => <span data-ai-id="judicial-process-selector-header-created-at">Criado em</span>,
+    cell: ({ row }) => <div className="min-w-[150px] text-sm">{row.original.createdAtLabel}</div>,
+  },
+  {
+    accessorKey: 'updatedAtLabel',
+    header: () => <span data-ai-id="judicial-process-selector-header-updated-at">Atualizado em</span>,
+    cell: ({ row }) => <div className="min-w-[150px] text-sm">{row.original.updatedAtLabel}</div>,
+  },
+];

--- a/src/components/admin/wizard/steps/step-2-judicial-setup.tsx
+++ b/src/components/admin/wizard/steps/step-2-judicial-setup.tsx
@@ -5,7 +5,10 @@ import { useWizard } from '../wizard-context';
 import type { JudicialProcess } from '@/types';
 import EntitySelector from '@/components/ui/entity-selector';
 import { useMemo, useState } from 'react';
-import type { ColumnDef } from '@tanstack/react-table';
+import {
+  buildJudicialProcessSelectorOptions,
+  judicialProcessSelectorColumns,
+} from '@/components/admin/judicial-processes/judicial-process-selector-config';
 
 interface Step2JudicialSetupProps {
   processes: JudicialProcess[];
@@ -18,40 +21,7 @@ export default function Step2JudicialSetup({ processes, onRefetchRequest, onAddN
   const [isFetching, setIsFetching] = useState(false);
 
   const selectedProcess = wizardData.judicialProcess;
-
-  const processDisplayColumns = useMemo<ColumnDef<any>[]>(() => [
-    {
-      accessorKey: 'processNumber',
-      header: 'Processo',
-      cell: ({ row }) => <div className="min-w-[180px] font-medium">{row.original.processNumber}</div>,
-    },
-    {
-      id: 'branch',
-      header: 'Vara / Comarca',
-      cell: ({ row }) => (
-        <div className="min-w-[220px] text-sm">
-          <div className="font-medium">{row.original.branchName || 'Vara não informada'}</div>
-          <div className="text-muted-foreground">{row.original.districtName || 'Comarca não informada'}</div>
-        </div>
-      ),
-    },
-    {
-      id: 'seller',
-      header: 'Comitente',
-      cell: ({ row }) => <div className="min-w-[180px] text-sm">{row.original.sellerName || 'Sem comitente vinculado'}</div>,
-    },
-    {
-      id: 'inventory',
-      header: 'Inventário',
-      cell: ({ row }) => (
-        <div className="min-w-[120px] text-sm text-muted-foreground">
-          {row.original.assetCount || 0} ativos
-          <br />
-          {row.original.lotCount || 0} lotes
-        </div>
-      ),
-    },
-  ], []);
+  const processOptions = useMemo(() => buildJudicialProcessSelectorOptions(processes), [processes]);
   
   const handleRefetch = async () => {
       setIsFetching(true);
@@ -71,32 +41,23 @@ export default function Step2JudicialSetup({ processes, onRefetchRequest, onAddN
         <h3 className="text-lg font-semibold">Selecione o Processo Judicial</h3>
       </div>
       <EntitySelector
-        entityName="Processo"
+        entityName="Processo Judicial"
         value={selectedProcess?.id}
         onChange={(processId) => {
             const process = processId ? processes.find(p => p.id === processId) : undefined;
             setWizardData((prev) => ({ ...prev, judicialProcess: process }));
         }}
-        options={processes.map((p) => ({
-          value: p.id,
-          label: p.processNumber,
-          processNumber: p.processNumber,
-          branchName: p.branchName,
-          districtName: p.districtName,
-          sellerName: p.sellerName,
-          assetCount: p.assetCount,
-          lotCount: p.lotCount,
-        }))}
+        options={processOptions}
         placeholder="Selecione um processo..."
-        searchPlaceholder="Buscar por processo, vara, comarca ou comitente..."
+        searchPlaceholder="Buscar por processo, comitente, vara, comarca, tribunal, partes, matrícula, registro ou CNJ..."
         emptyStateMessage="Nenhum processo encontrado."
         createNewUrl="/admin/judicial-processes/new"
         editUrlPrefix="/admin/judicial-processes"
         onRefetch={handleRefetch}
         isFetching={isFetching}
         onAddNew={onAddNewProcess}
-        displayColumns={processDisplayColumns}
-        dialogDescription="Pesquise por número CNJ, vara, comarca, comitente ou inventário relacionado antes de vincular o processo ao leilão."
+        displayColumns={judicialProcessSelectorColumns}
+        dialogDescription="Pesquise por número do processo, comitente, vara, comarca, tribunal, partes, matrícula, registro, tipo de ação, código CNJ e inventário relacionado antes de vincular o processo ao leilão."
       />
       
       {selectedProcess && (

--- a/src/components/ui/data-table-toolbar.tsx
+++ b/src/components/ui/data-table-toolbar.tsx
@@ -65,7 +65,8 @@ export function DataTableToolbar<TData>({
   onDeleteSelected,
   bulkActions = [],
 }: DataTableToolbarProps<TData>) {
-  const isFiltered = table.getState().columnFilters.length > 0;
+  const globalFilterValue = (table.getState().globalFilter as string) ?? "";
+  const isFiltered = table.getState().columnFilters.length > 0 || globalFilterValue.length > 0;
   const groupableColumns = table.getAllColumns().filter(c => c.getCanGroup());
   const groupingState = table.getState().grouping;
   const selectedRowsCount = table.getFilteredSelectedRowModel().rows.length;
@@ -102,10 +103,10 @@ export function DataTableToolbar<TData>({
         {searchColumnId && (
             <Input
             placeholder={searchPlaceholder}
-            value={(table.getColumn(searchColumnId)?.getFilterValue() as string) ?? ""}
-            onChange={(event) =>
-                table.getColumn(searchColumnId)?.setFilterValue(event.target.value)
-            }
+          value={globalFilterValue}
+          onChange={(event) =>
+            table.setGlobalFilter(event.target.value)
+          }
             className="h-8 w-full sm:w-[150px] lg:w-[250px]"
             data-ai-id="data-table-search-input"
             />
@@ -145,7 +146,10 @@ export function DataTableToolbar<TData>({
         {isFiltered && (
           <Button
             variant="ghost"
-            onClick={() => table.resetColumnFilters()}
+            onClick={() => {
+              table.resetColumnFilters();
+              table.setGlobalFilter('');
+            }}
             className="h-8 px-2 lg:px-3"
           >
             Limpar

--- a/tests/e2e/admin/judicial-process-selector-columns.spec.ts
+++ b/tests/e2e/admin/judicial-process-selector-columns.spec.ts
@@ -1,0 +1,44 @@
+/**
+ * @fileoverview Regressão E2E do modal compartilhado de Processo Judicial.
+ */
+
+import { expect, test } from '@playwright/test';
+
+import { loginAsAdmin } from '../helpers/auth-helper';
+
+const BASE_URL = process.env.PLAYWRIGHT_TEST_BASE_URL ?? 'http://demo.localhost:9006';
+
+test('admin auction form mostra colunas ampliadas no selector de processo judicial', async ({ page }) => {
+  test.setTimeout(240_000);
+
+  await loginAsAdmin(page, BASE_URL);
+
+  await page.request.get(`${BASE_URL}/admin/auctions/new`, {
+    failOnStatusCode: false,
+    timeout: 180_000,
+  });
+
+  await page.goto(`${BASE_URL}/admin/auctions/new`, {
+    waitUntil: 'domcontentloaded',
+    timeout: 180_000,
+  });
+
+  const trigger = page.locator('[data-ai-id="entity-selector-trigger-Processo Judicial"]');
+
+  await expect(trigger).toBeVisible({ timeout: 30_000 });
+  await trigger.click();
+
+  await expect(page.locator('[data-ai-id="entity-selector-modal-Processo Judicial"]')).toBeVisible();
+  await expect(page.locator('[data-ai-id="judicial-process-selector-header-process-number"]')).toBeVisible();
+  await expect(page.locator('[data-ai-id="judicial-process-selector-header-seller"]')).toBeVisible();
+  await expect(page.locator('[data-ai-id="judicial-process-selector-header-branch"]')).toBeVisible();
+  await expect(page.locator('[data-ai-id="judicial-process-selector-header-district"]')).toBeVisible();
+  await expect(page.locator('[data-ai-id="judicial-process-selector-header-court"]')).toBeVisible();
+  await expect(page.locator('[data-ai-id="judicial-process-selector-header-assets"]')).toBeVisible();
+  await expect(page.locator('[data-ai-id="judicial-process-selector-header-lots"]')).toBeVisible();
+
+  await page.screenshot({
+    path: 'test-results/judicial-process-selector-columns.png',
+    fullPage: true,
+  });
+});

--- a/tests/itsm/features/judicial-process-selector-columns.feature
+++ b/tests/itsm/features/judicial-process-selector-columns.feature
@@ -1,0 +1,11 @@
+Feature: Modal compartilhado de seleção de processo judicial
+  Como pessoa usuária do admin
+  Quero mais colunas no grid do processo judicial
+  Para diferenciar corretamente qual processo devo vincular ao leilão
+
+  Scenario: Modal judicial mostra colunas ampliadas sem perder bens e lotes
+    Given que estou em uma tela administrativa com seletor de processo judicial
+    When abro o modal de seleção de processo judicial
+    Then devo visualizar as colunas Processo, Comitente, Vara, Comarca e Tribunal
+    And devo visualizar as colunas Partes, Eletrônico, Matrícula, Registro, Tipo de ação, Cód. CNJ e Descrição da ação
+    And devo continuar visualizando as colunas Bens e Lotes no mesmo grid

--- a/tests/unit/judicial-process-selector-config.spec.ts
+++ b/tests/unit/judicial-process-selector-config.spec.ts
@@ -1,0 +1,80 @@
+/**
+ * @fileoverview Testes unitários do config compartilhado do selector de Processo Judicial.
+ */
+
+import { describe, expect, it } from 'vitest';
+
+import {
+  buildJudicialProcessSelectorOptions,
+  judicialProcessSelectorColumns,
+} from '@/components/admin/judicial-processes/judicial-process-selector-config';
+import type { JudicialProcess } from '@/types';
+
+describe('judicial-process-selector-config', () => {
+  it('preserva bens/lotes e expõe colunas ampliadas do processo judicial', () => {
+    const processes: JudicialProcess[] = [
+      {
+        id: '101',
+        publicId: 'PROC-101',
+        tenantId: '1',
+        processNumber: '0001234-56.2024.8.26.0100',
+        isElectronic: true,
+        createdAt: '2026-04-22T10:00:00.000Z',
+        updatedAt: '2026-04-22T12:00:00.000Z',
+        courtId: '11',
+        districtId: '12',
+        branchId: '13',
+        sellerId: '14',
+        propertyMatricula: 'MAT-8899',
+        propertyRegistrationNumber: 'REG-7788',
+        actionType: 'PENHORA',
+        actionDescription: 'Execução de título extrajudicial',
+        actionCnjCode: '123456',
+        parties: [
+          {
+            id: '1',
+            processId: '101',
+            name: 'Banco Alfa',
+            partyType: 'PLAINTIFF',
+            documentNumber: null,
+            tenantId: '1',
+          },
+          {
+            id: '2',
+            processId: '101',
+            name: 'Empresa Beta',
+            partyType: 'DEFENDANT',
+            documentNumber: null,
+            tenantId: '1',
+          },
+        ],
+        courtName: 'TJSP',
+        districtName: 'São Paulo',
+        branchName: '1ª Vara Cível',
+        sellerName: 'Massa Falida XPTO',
+        lotCount: 5,
+        assetCount: 2,
+        auctions: [],
+        lots: [],
+        assets: [],
+      },
+    ];
+
+    const [option] = buildJudicialProcessSelectorOptions(processes);
+
+    expect(option.processNumber).toBe('0001234-56.2024.8.26.0100');
+    expect(option.sellerName).toBe('Massa Falida XPTO');
+    expect(option.branchName).toBe('1ª Vara Cível');
+    expect(option.courtName).toBe('TJSP');
+    expect(option.propertyMatricula).toBe('MAT-8899');
+    expect(option.propertyRegistrationNumber).toBe('REG-7788');
+    expect(option.actionTypeLabel).toBe('Penhora');
+    expect(option.actionCnjCode).toBe('123456');
+    expect(option.assetCount).toBe(2);
+    expect(option.lotCount).toBe(5);
+    expect(option.partiesSummary).toContain('Plaintiff: Banco Alfa');
+    expect(option.partiesSummary).toContain('Defendant: Empresa Beta');
+
+    expect(judicialProcessSelectorColumns).toHaveLength(17);
+  });
+});


### PR DESCRIPTION
## Summary
- centralize the judicial-process selector column definitions in a shared config
- show richer judicial process fields across the selector grid while preserving asset and lot counts
- align shared table toolbar search with global filtering to avoid selector console noise

## Validation
- `npx vitest run tests/unit/judicial-process-selector-config.spec.ts --config vitest.unit.config.ts`
- `npm run typecheck`
- `npm run build`
- `npx playwright test tests/e2e/admin/judicial-process-selector-columns.spec.ts --config=playwright.config.local.ts`

## Notes
- updates consolidated business rules and the admin auction wizard integrity skill
- includes BDD coverage for the selector grid behavior