### PR TITLE
⚡ Optimize Judicial Process Count for Lawyers (Fix N+1)

### DIFF
--- a/PERFORMANCE_RATIONALE.md
+++ b/PERFORMANCE_RATIONALE.md
@@ -1,0 +1,30 @@
+# Performance Optimization Rationale: Judicial Process Count for Lawyers
+
+## Issue: N+1 Query Inefficiency
+In `src/services/admin-impersonation.service.ts`, the `getImpersonatableLawyers` method fetched up to 100 lawyers and then, for each lawyer with a CPF, executed a separate `prisma.judicialProcess.count` query.
+
+This resulted in:
+- 1 query to fetch the lawyers.
+- Up to 100 queries to count processes for each lawyer.
+
+Total: **101 queries** for 100 lawyers.
+
+## Benchmarking Limitations
+Establishing an automated performance baseline in the current environment was impractical due to:
+1. **Missing Dependencies**: The `node_modules` directory is absent.
+2. **Network Restrictions**: `npm install` and `npx` commands fail because registry.npmjs.org is unreachable.
+3. **Runtime Absence**: Without `node_modules`, standard TypeScript execution tools like `tsx` or `ts-node` are not functional for running benchmark scripts that depend on the project's infrastructure.
+
+## Rationale for Improvement
+The optimization replaces the N+1 pattern with a single batch query:
+1. Fetch lawyers.
+2. Collect all unique CPFs.
+3. Execute **one** query to find all process associations for those CPFs.
+4. Count and map the results in-memory.
+
+New Total: **2 queries** (regardless of the number of lawyers).
+
+### Expected Impact
+- **Database Load**: Significant reduction in the number of round-trips to the database.
+- **Latency**: Substantial improvement in response time, especially as the number of lawyers grows.
+- **Resource Utilization**: Reduced connection pool usage and database CPU cycles spent on query parsing and execution for multiple small identical-structured queries.

--- a/src/services/admin-impersonation.service.ts
+++ b/src/services/admin-impersonation.service.ts
@@ -83,34 +83,50 @@ export class AdminImpersonationService {
       take: 100,
     });
 
-    // Para cada advogado, conta processos ativos
-    const lawyersWithCounts = await Promise.all(
-      lawyers.map(async (lawyer) => {
-        let activeCasesCount = 0;
-        
-        if (lawyer.cpf) {
-          const processesCount = await prisma.judicialProcess.count({
-            where: {
-              JudicialParty: {
-                some: {
-                  documentNumber: lawyer.cpf,
-                  partyType: { in: ['ADVOGADO_AUTOR', 'ADVOGADO_REU'] },
-                },
-              },
-            },
-          });
-          activeCasesCount = processesCount;
-        }
+    // Lista de CPFs para busca em lote, otimizando o N+1 anterior
+    const cpfs = lawyers
+      .map((l) => l.cpf)
+      .filter((cpf): cpf is string => !!cpf);
 
-        return {
-          id: lawyer.id.toString(),
-          fullName: lawyer.fullName ?? 'Sem nome',
-          email: lawyer.email,
-          cpf: lawyer.cpf,
-          activeCasesCount,
-        };
-      })
-    );
+    const processCountsMap = new Map<string, number>();
+
+    if (cpfs.length > 0) {
+      // Busca todas as associações únicas de CPF -> Processo em uma única query
+      const partyAssociations = await prisma.judicialParty.findMany({
+        where: {
+          documentNumber: { in: cpfs },
+          partyType: { in: ['ADVOGADO_AUTOR', 'ADVOGADO_REU'] },
+        },
+        select: {
+          documentNumber: true,
+          processId: true,
+        },
+        distinct: ['documentNumber', 'processId'],
+      });
+
+      // Agrupa as contagens em memória
+      for (const assoc of partyAssociations) {
+        if (assoc.documentNumber) {
+          processCountsMap.set(
+            assoc.documentNumber,
+            (processCountsMap.get(assoc.documentNumber) || 0) + 1
+          );
+        }
+      }
+    }
+
+    // Mapeia os advogados com os contadores pré-calculados
+    const lawyersWithCounts = lawyers.map((lawyer) => {
+      const activeCasesCount = lawyer.cpf ? (processCountsMap.get(lawyer.cpf) || 0) : 0;
+
+      return {
+        id: lawyer.id.toString(),
+        fullName: lawyer.fullName ?? 'Sem nome',
+        email: lawyer.email,
+        cpf: lawyer.cpf,
+        activeCasesCount,
+      };
+    });
 
     return lawyersWithCounts.sort((a, b) => b.activeCasesCount - a.activeCasesCount);
   }


### PR DESCRIPTION
💡 **What:** The optimization implemented
- Refactored `getImpersonatableLawyers` in `src/services/admin-impersonation.service.ts` to use a batch query for process counts.
- Replaced a loop of `prisma.judicialProcess.count` with a single `prisma.judicialParty.findMany` call using `distinct`.
- Added `PERFORMANCE_RATIONALE.md` explaining the architectural improvement.

🎯 **Why:** The performance problem it solves
- N+1 query issue: For $N$ lawyers, the service was making $N+1$ database queries. At the default limit of 100 lawyers, this meant 101 queries per request.
- Unnecessary database load and increased latency for admin users.

📊 **Measured Improvement:**
- **Theoretical Improvement**: Reduced database round-trips from $O(N)$ to $O(1)$ (specifically from 101 to 2 queries for 100 lawyers).
- **Environmental Note**: Automated benchmarking was impractical due to the absence of `node_modules` and network restrictions in the current sandbox environment, as documented in `PERFORMANCE_RATIONALE.md`. However, the shift from a linear number of queries to a constant number is a guaranteed performance win in database-driven applications.

---
*PR created automatically by Jules for task [2055702367487416008](https://jules.google.com/task/2055702367487416008) started by @augustodevcode*