### PR TITLE
🧪 [testing improvement] Unit tests for getRuntimeCurrencyPreference

### DIFF
--- a/src/lib/__tests__/format.test.ts
+++ b/src/lib/__tests__/format.test.ts
@@ -2,8 +2,8 @@
  * @fileoverview Testes unitários para normalização e formatação monetária.
  */
 
-import { describe, expect, it } from 'vitest';
-import { formatCurrency, toMonetaryNumber } from '@/lib/format';
+import { describe, expect, it, vi, beforeEach, afterEach } from 'vitest';
+import { formatCurrency, toMonetaryNumber, getRuntimeCurrencyPreference, setRuntimeCurrencyPreference } from '@/lib/format';
 
 describe('toMonetaryNumber', () => {
   it('converte number sem alteração', () => {
@@ -25,6 +25,69 @@ describe('toMonetaryNumber', () => {
   it('converte decimal-like com toNumber', () => {
     const decimalLike = { toNumber: () => 1234.56 };
     expect(toMonetaryNumber(decimalLike)).toBe(1234.56);
+  });
+});
+
+describe('getRuntimeCurrencyPreference', () => {
+  let originalWindow: typeof window;
+
+  beforeEach(() => {
+    // Save original window object
+    originalWindow = global.window;
+    // Reset runtime preference
+    setRuntimeCurrencyPreference(null);
+  });
+
+  afterEach(() => {
+    // Restore original window
+    global.window = originalWindow;
+    vi.restoreAllMocks();
+  });
+
+  it('retorna preferência em runtime se definida', () => {
+    setRuntimeCurrencyPreference('EUR');
+    expect(getRuntimeCurrencyPreference()).toBe('EUR');
+  });
+
+  it('retorna BRL se window estiver undefined (ex: SSR)', () => {
+    // Mock window to undefined
+    vi.stubGlobal('window', undefined);
+
+    expect(getRuntimeCurrencyPreference()).toBe('BRL');
+  });
+
+  it('retorna preferência salva no localStorage se disponível e válida', () => {
+    const mockGetItem = vi.fn().mockReturnValue('USD');
+    const mockLocalStorage = {
+      getItem: mockGetItem,
+    };
+
+    vi.stubGlobal('window', { localStorage: mockLocalStorage });
+
+    expect(getRuntimeCurrencyPreference()).toBe('USD');
+    expect(mockGetItem).toHaveBeenCalledWith('bidexpert:selected-currency');
+  });
+
+  it('retorna BRL se localStorage estiver vazio', () => {
+    const mockGetItem = vi.fn().mockReturnValue(null);
+    const mockLocalStorage = {
+      getItem: mockGetItem,
+    };
+
+    vi.stubGlobal('window', { localStorage: mockLocalStorage });
+
+    expect(getRuntimeCurrencyPreference()).toBe('BRL');
+  });
+
+  it('retorna BRL se localStorage contiver valor inválido', () => {
+    const mockGetItem = vi.fn().mockReturnValue('INVALID_CURRENCY');
+    const mockLocalStorage = {
+      getItem: mockGetItem,
+    };
+
+    vi.stubGlobal('window', { localStorage: mockLocalStorage });
+
+    expect(getRuntimeCurrencyPreference()).toBe('BRL');
   });
 });
 

--- a/src/lib/format.ts
+++ b/src/lib/format.ts
@@ -40,7 +40,7 @@ function parseRuntimeCurrency(value: string | null): SupportedCurrency | null {
   return null;
 }
 
-export function setRuntimeCurrencyPreference(currency: SupportedCurrency): void {
+export function setRuntimeCurrencyPreference(currency: SupportedCurrency | null): void {
   runtimeCurrencyPreference = currency;
 }
 


### PR DESCRIPTION
🎯 **What:** Added tests for the `getRuntimeCurrencyPreference` function to ensure its fallback chain behaves correctly (runtime internal state -> `localStorage` -> default 'BRL' -> SSR handling). To facilitate this, `setRuntimeCurrencyPreference` was updated to accept `null` for better test isolation.
📊 **Coverage:** Covered all paths in the fallback chain:
- Returns preference in runtime if set.
- Returns 'BRL' if `window` is `undefined` (SSR).
- Returns the saved preference in `localStorage` if it's available and valid.
- Fallbacks to 'BRL' if `localStorage` is empty or has invalid data.
✨ **Result:** Improved test coverage for currency preference retrieval and isolated the application format state effectively for future unit tests.

---
*PR created automatically by Jules for task [15799887911957437513](https://jules.google.com/task/15799887911957437513) started by @augustodevcode*