### PR TITLE
fix: move query monitor toggle to sidebar footer

### DIFF
--- a/src/components/layout/admin-header.tsx
+++ b/src/components/layout/admin-header.tsx
@@ -6,7 +6,7 @@
  */
 'use client';
 
-import { Search, Bell, Settings, MessageSquare, Menu, Globe, Activity } from 'lucide-react';
+import { Search, Bell, Settings, MessageSquare, Menu, Globe } from 'lucide-react';
 import { Button } from '@/components/ui/button';
 import { useAuth } from '@/contexts/auth-context';
 import UserNav from './user-nav';
@@ -14,9 +14,6 @@ import Link from 'next/link';
 import { Badge } from '../ui/badge';
 import { TooltipProvider, Tooltip, TooltipTrigger, TooltipContent } from '../ui/tooltip';
 import { ThemeToggle } from './theme-toggle';
-import { Switch } from '@/components/ui/switch';
-import { Label } from '@/components/ui/label';
-import { cn } from '@/lib/utils';
 
 interface AdminHeaderProps {
   onSearchClick: () => void;
@@ -61,36 +58,6 @@ export default function AdminHeader({
       </div>
 
       <div className="wrapper-admin-header-spacer">
-        {/* Feature Flag: Query Monitor Toggle */}
-        <div className="flex items-center gap-2 px-2 border-r border-border/50" data-ai-id="admin-header-query-monitor-toggle">
-          <TooltipProvider>
-            <Tooltip>
-              <TooltipTrigger asChild side="bottom">
-                <div className="flex items-center gap-2 cursor-help">
-                  <Activity className={cn(
-                    "h-4 w-4 transition-colors",
-                    queryMonitorEnabled ? "text-primary animate-pulse" : "text-muted-foreground"
-                  )} />
-                  <Label htmlFor="query-monitor-toggle" className="text-xs font-medium cursor-pointer hidden md:inline-block">
-                    Monitor
-                  </Label>
-                  <Switch
-                    id="query-monitor-toggle"
-                    checked={queryMonitorEnabled}
-                    onCheckedChange={onQueryMonitorToggle}
-                    data-ai-id="query-monitor-toggle-switch"
-                    className="scale-75"
-                  />
-                </div>
-              </TooltipTrigger>
-              <TooltipContent side="bottom">
-                <p className="text-xs">
-                  {queryMonitorEnabled ? 'Desativar' : 'Ativar'} Monitor de Queries (Debug)
-                </p>
-              </TooltipContent>
-            </Tooltip>
-          </TooltipProvider>
-        </div>
       </div>
 
       {/* Ícones de Ação e Menu do Usuário */}

--- a/src/components/layout/env-info-button.tsx
+++ b/src/components/layout/env-info-button.tsx
@@ -3,9 +3,12 @@
  */
 'use client';
 
-import { useState } from 'react';
-import { Terminal } from 'lucide-react';
+import { useEffect, useState } from 'react';
+import { Activity, Terminal } from 'lucide-react';
 import { Button } from '@/components/ui/button';
+import { Label } from '@/components/ui/label';
+import { Switch } from '@/components/ui/switch';
+import { Tooltip, TooltipContent, TooltipProvider, TooltipTrigger } from '@/components/ui/tooltip';
 import {
   Dialog,
   DialogContent,
@@ -22,9 +25,42 @@ interface EnvInfoButtonProps {
   collapsed?: boolean;
 }
 
+const QUERY_MONITOR_LS_KEY = 'admin_query_monitor_enabled';
+const ENV_QUERY_MONITOR = process.env.NEXT_PUBLIC_QUERY_MONITOR_ENABLED === 'true';
+
 export default function EnvInfoButton({ onLinkClick, collapsed = false }: EnvInfoButtonProps) {
   const [open, setOpen] = useState(false);
+  const [mounted, setMounted] = useState(false);
+  const [queryMonitorEnabled, setQueryMonitorEnabled] = useState(false);
   const { userProfileWithPermissions, activeTenantId } = useAuth();
+
+  useEffect(() => {
+    setMounted(true);
+
+    if (ENV_QUERY_MONITOR) {
+      setQueryMonitorEnabled(true);
+      return;
+    }
+
+    const stored = localStorage.getItem(QUERY_MONITOR_LS_KEY);
+    setQueryMonitorEnabled(stored === 'true');
+  }, []);
+
+  const handleQueryMonitorToggle = (checked: boolean) => {
+    if (ENV_QUERY_MONITOR) {
+      return;
+    }
+
+    setQueryMonitorEnabled(checked);
+    const nextValue = checked ? 'true' : 'false';
+    localStorage.setItem(QUERY_MONITOR_LS_KEY, nextValue);
+    window.dispatchEvent(
+      new StorageEvent('storage', {
+        key: QUERY_MONITOR_LS_KEY,
+        newValue: nextValue,
+      })
+    );
+  };
 
   const tenantId =
     activeTenantId ||
@@ -38,20 +74,69 @@ export default function EnvInfoButton({ onLinkClick, collapsed = false }: EnvInf
 
   return (
     <>
-      <Button
-        variant="ghost"
-        data-ai-id="env-info-sidebar-button"
-        className={cn(
-          'h-9 text-sm text-sidebar-foreground/60 hover:bg-sidebar-accent hover:text-sidebar-accent-foreground',
-          collapsed ? 'w-full justify-center px-2' : 'w-full justify-start'
+      <div className={cn('flex w-full items-center justify-between', collapsed ? 'flex-col gap-2' : 'gap-2')}>
+        <Button
+          variant="ghost"
+          data-ai-id="env-info-sidebar-button"
+          className={cn(
+            'h-9 text-sm text-sidebar-foreground/60 hover:bg-sidebar-accent hover:text-sidebar-accent-foreground',
+            collapsed ? 'w-full justify-center px-2' : 'flex-1 justify-start px-2'
+          )}
+          onClick={handleOpen}
+          title="Dev Info"
+          aria-label="Dev Info"
+        >
+          <Terminal className={cn('h-4 w-4', !collapsed && 'mr-2')} />
+          {!collapsed ? 'Dev Info' : <span className="sr-only">Dev Info</span>}
+        </Button>
+
+        {mounted && (
+          <TooltipProvider>
+            <Tooltip>
+              <TooltipTrigger asChild>
+                <div
+                  className={cn(
+                    'flex min-w-0 items-center gap-1 rounded-md px-2 text-sidebar-foreground/60',
+                    collapsed ? 'w-full justify-center' : 'shrink-0 justify-end'
+                  )}
+                  data-ai-id="sidebar-query-monitor-toggle"
+                >
+                  <Activity
+                    className={cn(
+                      'h-4 w-4 transition-colors',
+                      queryMonitorEnabled ? 'text-primary animate-pulse' : 'text-sidebar-foreground/40'
+                    )}
+                  />
+                  {!collapsed ? (
+                    <Label htmlFor="query-monitor-sidebar-toggle" className="cursor-pointer text-xs font-medium">
+                      Monitor
+                    </Label>
+                  ) : (
+                    <span className="sr-only">Monitor de Queries</span>
+                  )}
+                  <Switch
+                    id="query-monitor-sidebar-toggle"
+                    checked={queryMonitorEnabled}
+                    onCheckedChange={handleQueryMonitorToggle}
+                    data-ai-id="query-monitor-toggle-switch"
+                    className="scale-75"
+                    disabled={ENV_QUERY_MONITOR}
+                    aria-label="Monitor de Queries"
+                  />
+                </div>
+              </TooltipTrigger>
+              <TooltipContent side={collapsed ? 'right' : 'top'}>
+                <p className="text-xs">
+                  {queryMonitorEnabled ? 'Desativar' : 'Ativar'} Monitor de Queries (Debug)
+                </p>
+                {ENV_QUERY_MONITOR && (
+                  <p className="mt-1 text-xs text-amber-500">Habilitado via ENV</p>
+                )}
+              </TooltipContent>
+            </Tooltip>
+          </TooltipProvider>
         )}
-        onClick={handleOpen}
-        title="Dev Info"
-        aria-label="Dev Info"
-      >
-        <Terminal className={cn('h-4 w-4', !collapsed && 'mr-2')} />
-        {!collapsed ? 'Dev Info' : <span className="sr-only">Dev Info</span>}
-      </Button>
+      </div>
 
       <Dialog open={open} onOpenChange={setOpen}>
         <DialogContent


### PR DESCRIPTION
## Summary
- remove the Query Monitor toggle from the admin header
- render the toggle next to Dev Info in the sidebar footer
- preserve the existing localStorage and storage-event sync used by AdminQueryMonitor

## Validation
- npm run typecheck
- npm run build