### PR TITLE
fix: reorder admin dashboard kpis and quick links

### DIFF
--- a/context/REGRAS_NEGOCIO_CONSOLIDADO.md
+++ b/context/REGRAS_NEGOCIO_CONSOLIDADO.md
@@ -3249,6 +3249,21 @@ interface EntityConfig {
 
 ---
 
+### RN-AP-008A: Hierarquia visual do dashboard administrativo
+
+✅ A rota `/admin/dashboard` DEVE renderizar a seção `Visão geral e KPIs` antes da seção `Acessos rápidos`.
+✅ Os atalhos operacionais DEVEM permanecer agrupados em uma seção única imediatamente abaixo dos KPIs.
+✅ A seção `Acessos rápidos` DEVE aparecer antes dos gráficos de desempenho; é proibido intercalar os atalhos entre cards de KPI ou abaixo dos gráficos.
+✅ Mudanças de ordenação nessas seções DEVEM ser cobertas por teste E2E com verificação explícita da posição relativa entre `Visão geral e KPIs` e `Acessos rápidos`.
+
+**BDD - KPIs antecedem os atalhos no dashboard administrativo**
+- **Dado** que o dashboard administrativo possui métricas e atalhos operacionais disponíveis
+- **Quando** o administrador acessa `/admin/dashboard`
+- **Então** a seção `Visão geral e KPIs` deve aparecer antes da seção `Acessos rápidos`
+- **E** a seção `Acessos rápidos` deve permanecer acima dos gráficos de desempenho
+
+---
+
 ### RN-AP-009: Componentes de Infraestrutura
 
 **Componentes compartilhados em `src/components/admin-plus/`:**

--- a/src/app/admin/dashboard/page.tsx
+++ b/src/app/admin/dashboard/page.tsx
@@ -238,22 +238,6 @@ export default function AdminDashboardPage() {
 
   return (
     <div className="container-admin-dashboard flex flex-col gap-8 pb-10" data-ai-id="admin-dashboard-page-container">
-      <section className="space-y-4" aria-labelledby="admin-dashboard-quick-access-title">
-        <div className="space-y-1">
-          <h2 id="admin-dashboard-quick-access-title" className="text-2xl font-bold tracking-tight text-foreground">
-            Acessos rápidos
-          </h2>
-          <p className="text-sm text-muted-foreground">
-            Atalhos para as superfícies mais usadas na operação diária da plataforma.
-          </p>
-        </div>
-        <div className="grid grid-cols-1 gap-4 sm:grid-cols-2 xl:grid-cols-5" data-ai-id="admin-dashboard-quicklinks-grid">
-          {QUICK_LINKS.map((item) => (
-            <QuickLinkCard key={item.dataAiId} {...item} />
-          ))}
-        </div>
-      </section>
-
       <section className="space-y-4" aria-labelledby="admin-dashboard-kpis-title">
         <div className="space-y-1">
           <h2 id="admin-dashboard-kpis-title" className="text-2xl font-bold tracking-tight text-foreground">
@@ -349,6 +333,22 @@ export default function AdminDashboardPage() {
             isLoading={isLoading}
             dataAiId="admin-dashboard-stat-sellers"
           />
+        </div>
+      </section>
+
+      <section className="space-y-4" aria-labelledby="admin-dashboard-quick-access-title">
+        <div className="space-y-1">
+          <h2 id="admin-dashboard-quick-access-title" className="text-2xl font-bold tracking-tight text-foreground">
+            Acessos rápidos
+          </h2>
+          <p className="text-sm text-muted-foreground">
+            Atalhos para as superfícies mais usadas na operação diária da plataforma.
+          </p>
+        </div>
+        <div className="grid grid-cols-1 gap-4 sm:grid-cols-2 xl:grid-cols-5" data-ai-id="admin-dashboard-quicklinks-grid">
+          {QUICK_LINKS.map((item) => (
+            <QuickLinkCard key={item.dataAiId} {...item} />
+          ))}
         </div>
       </section>
 

--- a/tests/e2e/admin-dashboard-real-data.spec.ts
+++ b/tests/e2e/admin-dashboard-real-data.spec.ts
@@ -32,5 +32,13 @@ test.describe('Dashboard Admin - Dados Reais', () => {
     await expect(quickLinksGrid).toContainText('Novo leilão');
     await expect(quickLinksGrid).toContainText('Marketing');
     await expect(quickLinksGrid).toContainText('Processos');
+
+    const kpiSection = page.getByRole('region', { name: 'Visão geral e KPIs' });
+    const quickAccessSection = page.getByRole('region', { name: 'Acessos rápidos' });
+
+    const kpiBottom = await kpiSection.evaluate((el) => el.getBoundingClientRect().bottom);
+    const quickAccessTop = await quickAccessSection.evaluate((el) => el.getBoundingClientRect().top);
+
+    expect(kpiBottom).toBeLessThan(quickAccessTop);
   });
 });

--- a/tests/itsm/features/admin-dashboard.feature
+++ b/tests/itsm/features/admin-dashboard.feature
@@ -15,3 +15,9 @@ Funcionalidade: Dashboard Administrativo - Dados Reais
     Quando eu acesso o dashboard administrativo
     Então devo ver atalhos para Novo leilão, Leilões, Lotes, Ativos, Mídias, Marketing, Processos, Comitentes, Usuários e Configurações
     E devo ver os indicadores Taxa de sucesso, Ticket médio, Lotes por leilão e Comitentes ativos
+
+  Cenário: Posicionar KPIs antes dos acessos rápidos
+    Dado que existem métricas e atalhos operacionais disponíveis para o administrador
+    Quando eu acesso o dashboard administrativo
+    Então a seção "Visão geral e KPIs" deve aparecer antes da seção "Acessos rápidos"
+    E a seção "Acessos rápidos" deve permanecer antes dos gráficos de desempenho


### PR DESCRIPTION
## Resumo
- reposiciona a seção de KPIs acima dos acessos rápidos no dashboard admin
- adiciona verificação E2E para a ordem relativa entre KPIs e atalhos
- documenta a regra no consolidado e no feature BDD do dashboard

## Validações
- npx playwright test tests/e2e/admin-dashboard-real-data.spec.ts --config='E:/bw/admindash-order-20260423-2315/.tmp-playwright-dashboard-local.config.ts' --project=chromium (BASE_URL=http://127.0.0.1:9007)
- npm run typecheck
