### PR TITLE
feat(admin): galeria de fotos em ativo + herança opcional no lote

### DIFF
--- a/context/REGRAS_NEGOCIO_CONSOLIDADO.md
+++ b/context/REGRAS_NEGOCIO_CONSOLIDADO.md
@@ -165,6 +165,21 @@ Controller (Server Action) → Service → Repository → ZOD → Prisma ORM →
 ✅ Leilão pode herdar imagem de Lote vinculado  
 ✅ Prioriza galeria/imagem customizada se existir  
 ✅ Lógica centralizada nos Services
+✅ Formulário de `Asset` DEVE permitir cadastro de galeria de fotos com vínculo persistível (`mediaItemIds`) além da imagem principal.
+✅ Quando o operador escolher herança no formulário de `Lot`, o payload salvo DEVE receber um snapshot da mídia do `Asset` escolhido (imagem principal + galeria), sem depender de campo sentinela em FK BigInt.
+✅ Quando o operador optar por galeria customizada do `Lot`, a leitura pública DEVE priorizar mídia própria do lote e NÃO mesclar automaticamente fallback de `Asset` quando já existir mídia customizada.
+
+**Cenário BDD - Ativo com galeria persistível**
+- **Dado** um ativo em cadastro administrativo
+- **Quando** a pessoa adiciona imagens na galeria pela biblioteca de mídia
+- **Então** o sistema persiste `galleryImageUrls` e `mediaItemIds`
+- **E** as miniaturas permanecem visíveis no formulário para revisão
+
+**Cenário BDD - Lote com herança opcional de galeria**
+- **Dado** um lote com bens vinculados e um bem com galeria preenchida
+- **Quando** a pessoa seleciona herdar a galeria desse bem e salva o lote
+- **Então** o lote persiste imagem principal e galeria herdadas do bem selecionado
+- **E** se a pessoa escolher modo customizado, prevalece apenas a galeria própria do lote
 
 ### RN-006: Schema Prisma
 ✅ Usar arquivo único tradicional `prisma/schema.prisma`  

--- a/src/app/admin/assets/asset-form-v2.tsx
+++ b/src/app/admin/assets/asset-form-v2.tsx
@@ -128,6 +128,8 @@ export function AssetFormV2({
   });
 
   const selectedCategoryId = useWatch({ control: form.control, name: 'categoryId' });
+    const watchedMainImageUrl = useWatch({ control: form.control, name: 'imageUrl' });
+    const watchedGalleryImageUrls = useWatch({ control: form.control, name: 'galleryImageUrls' }) || [];
   const selectedCategory = safeCategories.find(c => c.id.toString() === selectedCategoryId);
   console.log('AssetFormV2: selectedCategoryId', selectedCategoryId);
   console.log('AssetFormV2: selectedCategory', selectedCategory);
@@ -146,27 +148,53 @@ export function AssetFormV2({
   }, [selectedCategoryId]);
 
     const handleMediaSelect = (selectedItems: any[]) => {
-        const media = selectedItems?.[0];
-        if (!media) {
+        if (!selectedItems?.length) {
             setIsMediaDialogOpen(false);
             setDialogTarget(null);
             return;
         }
 
-        const selectedUrl = media.urlOriginal || media.urlThumbnail || media.url || '';
-
         if (dialogTarget === 'main') {
-            form.setValue('imageUrl', selectedUrl);
-            form.setValue('imageMediaId', media.id.toString());
+            const media = selectedItems[0];
+            const selectedUrl = media?.urlOriginal || media?.urlThumbnail || media?.url || '';
+            const selectedId = media?.id?.toString?.();
+            form.setValue('imageUrl', selectedUrl, { shouldDirty: true, shouldValidate: true });
+            form.setValue('imageMediaId', selectedId || '', { shouldDirty: true, shouldValidate: true });
         } else if (dialogTarget === 'gallery') {
-      const currentUrls = form.getValues('galleryImageUrls') || [];
-      const currentIds = form.getValues('mediaItemIds') || [];
-            form.setValue('galleryImageUrls', [...currentUrls, selectedUrl]);
-      form.setValue('mediaItemIds', [...currentIds, media.id.toString()]);
-    }
-    setIsMediaDialogOpen(false);
-    setDialogTarget(null);
-  };
+            const currentUrls = form.getValues('galleryImageUrls') || [];
+            const currentIds = form.getValues('mediaItemIds') || [];
+            const nextUrls = [...currentUrls];
+            const nextIds = [...currentIds];
+
+            selectedItems.forEach((media: any) => {
+                const selectedUrl = media?.urlOriginal || media?.urlThumbnail || media?.url || '';
+                const selectedId = media?.id?.toString?.();
+                if (selectedUrl && !nextUrls.includes(selectedUrl)) nextUrls.push(selectedUrl);
+                if (selectedId && !nextIds.includes(selectedId)) nextIds.push(selectedId);
+            });
+
+            form.setValue('galleryImageUrls', nextUrls, { shouldDirty: true, shouldValidate: true });
+            form.setValue('mediaItemIds', nextIds, { shouldDirty: true, shouldValidate: true });
+        }
+
+        setIsMediaDialogOpen(false);
+        setDialogTarget(null);
+    };
+
+    const handleRemoveGalleryImage = (indexToRemove: number) => {
+        const currentUrls = form.getValues('galleryImageUrls') || [];
+        const currentIds = form.getValues('mediaItemIds') || [];
+        form.setValue(
+            'galleryImageUrls',
+            currentUrls.filter((_, index) => index !== indexToRemove),
+            { shouldDirty: true, shouldValidate: true }
+        );
+        form.setValue(
+            'mediaItemIds',
+            currentIds.filter((_, index) => index !== indexToRemove),
+            { shouldDirty: true, shouldValidate: true }
+        );
+    };
 
   return (
     <CrudFormLayout
@@ -181,7 +209,7 @@ export function AssetFormV2({
       }
     >
       <Form {...form}>
-        <form onSubmit={handleSubmit} className="space-y-8">
+        <form onSubmit={handleSubmit} className="space-y-8" data-ai-id="asset-form">
             {/* Main Content Grid */}
             <div className="grid grid-cols-1 lg:grid-cols-3 gap-8">
                 {/* Left Column: Basic Info */}
@@ -417,10 +445,10 @@ export function AssetFormV2({
                         </CardHeader>
                         <CardContent className="space-y-4">
                             <div className="flex flex-col items-center justify-center border-2 border-dashed rounded-lg p-4 min-h-[150px] bg-muted/10">
-                                {form.watch('imageUrl') ? (
+                                {watchedMainImageUrl ? (
                                     <div className="relative w-full aspect-video">
                                         <Image 
-                                            src={form.watch('imageUrl')!} 
+                                            src={watchedMainImageUrl} 
                                             alt="Preview" 
                                             fill 
                                             className="object-cover rounded-md"
@@ -431,8 +459,8 @@ export function AssetFormV2({
                                             size="icon"
                                             className="absolute top-2 right-2 h-6 w-6"
                                             onClick={() => {
-                                                form.setValue('imageUrl', '');
-                                                form.setValue('imageMediaId', '');
+                                                form.setValue('imageUrl', '', { shouldDirty: true, shouldValidate: true });
+                                                form.setValue('imageMediaId', '', { shouldDirty: true, shouldValidate: true });
                                             }}
                                         >
                                             <Trash2 className="h-3 w-3" />
@@ -453,9 +481,67 @@ export function AssetFormV2({
                                     setDialogTarget('main');
                                     setIsMediaDialogOpen(true);
                                 }}
+                                data-ai-id="asset-main-image-open-library-button"
                             >
                                 Selecionar da Biblioteca
                             </Button>
+                        </CardContent>
+                    </Card>
+
+                    <Card data-ai-id="asset-gallery-card">
+                        <CardHeader>
+                            <CardTitle className="text-base flex items-center gap-2">
+                                <ImagePlus className="h-4 w-4" />
+                                Galeria de Fotos
+                            </CardTitle>
+                        </CardHeader>
+                        <CardContent className="space-y-4" data-ai-id="asset-gallery-content">
+                            <Button
+                                type="button"
+                                variant="outline"
+                                className="w-full"
+                                onClick={() => {
+                                    setDialogTarget('gallery');
+                                    setIsMediaDialogOpen(true);
+                                }}
+                                data-ai-id="asset-gallery-open-library-button"
+                            >
+                                Adicionar à Galeria
+                            </Button>
+
+                            <div className="grid grid-cols-3 gap-2" data-ai-id="asset-gallery-grid">
+                                {watchedGalleryImageUrls.length > 0 ? (
+                                    watchedGalleryImageUrls.map((url, index) => (
+                                        <div key={`${url}-${index}`} className="relative aspect-square rounded-md overflow-hidden border bg-muted/10" data-ai-id="asset-gallery-item">
+                                            <Image
+                                                src={url}
+                                                alt={`Imagem da galeria ${index + 1}`}
+                                                fill
+                                                className="object-cover"
+                                            />
+                                            <Button
+                                                type="button"
+                                                variant="destructive"
+                                                size="icon"
+                                                className="absolute top-1 right-1 h-6 w-6"
+                                                onClick={() => handleRemoveGalleryImage(index)}
+                                                aria-label={`Remover imagem ${index + 1} da galeria`}
+                                                data-ai-id="asset-gallery-remove-button"
+                                            >
+                                                <Trash2 className="h-3 w-3" />
+                                            </Button>
+                                        </div>
+                                    ))
+                                ) : (
+                                    <p className="col-span-3 text-xs text-muted-foreground text-center py-4" data-ai-id="asset-gallery-empty-state">
+                                        Nenhuma imagem na galeria.
+                                    </p>
+                                )}
+                            </div>
+
+                            <FormDescription>
+                                As imagens da galeria podem ser herdadas pelos lotes vinculados quando desejado.
+                            </FormDescription>
                         </CardContent>
                     </Card>
                 </div>
@@ -475,6 +561,7 @@ export function AssetFormV2({
         isOpen={isMediaDialogOpen} 
         onOpenChange={setIsMediaDialogOpen}
                 onMediaSelect={handleMediaSelect}
+                allowMultiple={dialogTarget === 'gallery'}
       />
     </CrudFormLayout>
   );

--- a/src/app/admin/lots/lot-form.tsx
+++ b/src/app/admin/lots/lot-form.tsx
@@ -243,6 +243,17 @@ const LotForm = forwardRef<any, LotFormProps>(({
       if (!inheritedMediaFromAssetId) return null;
       return linkedAssetsDetails.find(asset => asset.id === inheritedMediaFromAssetId);
   }, [inheritedMediaFromAssetId, linkedAssetsDetails]);
+
+  const normalizeAssetMediaIds = useCallback((rawMediaIds: unknown): string[] => {
+    if (!Array.isArray(rawMediaIds)) return [];
+    return Array.from(
+      new Set(
+        rawMediaIds
+          .map((mediaId) => (mediaId === null || mediaId === undefined ? '' : String(mediaId).trim()))
+          .filter((mediaId) => mediaId.length > 0)
+      )
+    );
+  }, []);
   
   const displayImageUrl = inheritedAssetDetails?.imageUrl || imageUrlPreview;
 
@@ -251,6 +262,14 @@ const LotForm = forwardRef<any, LotFormProps>(({
       setAssetRowSelection({});
     }
   }, [assetRowSelection, isAssetLinkingLocked]);
+
+  useEffect(() => {
+    if (!inheritedMediaFromAssetId) return;
+    const inheritedStillLinked = linkedAssetsDetails.some((asset) => asset.id === inheritedMediaFromAssetId);
+    if (!inheritedStillLinked) {
+      form.setValue('inheritedMediaFromAssetId', null, { shouldDirty: true });
+    }
+  }, [form, inheritedMediaFromAssetId, linkedAssetsDetails]);
 
 
   const handleRefetchAuctions = useCallback(async () => {
@@ -304,7 +323,33 @@ const LotForm = forwardRef<any, LotFormProps>(({
   async function onSubmit(values: LotFormValues) {
     setIsSubmitting(true);
     try {
-      const result = await onSubmitAction(values);
+      const payload: LotFormValues = {
+        ...values,
+      };
+
+      if (payload.inheritedMediaFromAssetId) {
+        const sourceAsset = linkedAssetsDetails.find((asset) => asset.id === payload.inheritedMediaFromAssetId);
+        if (!sourceAsset) {
+          toast({
+            title: 'Bem de origem não encontrado',
+            description: 'Selecione novamente o bem para herdar a galeria ou use galeria customizada.',
+            variant: 'destructive',
+          });
+          setIsSubmitting(false);
+          return;
+        }
+
+        const inheritedGalleryUrls = Array.from(
+          new Set((sourceAsset.galleryImageUrls || []).filter((url): url is string => typeof url === 'string' && url.trim().length > 0))
+        );
+
+        payload.imageUrl = sourceAsset.imageUrl || payload.imageUrl || '';
+        payload.imageMediaId = sourceAsset.imageMediaId || null;
+        payload.galleryImageUrls = inheritedGalleryUrls;
+        payload.mediaItemIds = normalizeAssetMediaIds(sourceAsset.mediaItemIds);
+      }
+
+      const result = await onSubmitAction(payload);
       if (result.success) {
         toast({ title: 'Sucesso!', description: result.message });
         const returnToPath = searchParams.get('returnTo');
@@ -363,6 +408,9 @@ const LotForm = forwardRef<any, LotFormProps>(({
       const currentAssetIds = form.getValues('assetIds') || [];
       const newAssetIds = currentAssetIds.filter(id => id !== assetIdToUnlink);
       form.setValue('assetIds', newAssetIds, { shouldDirty: true });
+      if (form.getValues('inheritedMediaFromAssetId') === assetIdToUnlink) {
+        form.setValue('inheritedMediaFromAssetId', null, { shouldDirty: true });
+      }
       toast({ title: 'Bem desvinculado.' });
   };
     
@@ -630,9 +678,9 @@ const LotForm = forwardRef<any, LotFormProps>(({
 
                       <Separator />
 
-                      <section className="space-y-4">
+                       <section className="space-y-4" data-ai-id="lot-form-media-section">
                          <h3 className="text-lg font-semibold text-primary border-b pb-2">Mídia do Lote</h3>
-                         <FormField control={controlAny} name="inheritedMediaFromAssetId" render={({ field }) => (<FormItem className="space-y-3 p-4 border rounded-md bg-background"><FormLabel className="text-base font-semibold">Fonte da Galeria de Imagens</FormLabel><FormControl><RadioGroup onValueChange={(value) => field.onChange(value === "custom" ? null : value)} value={field.value ? field.value : "custom"} className="flex flex-col sm:flex-row gap-4"><Label className="flex items-center space-x-2 p-3 border rounded-md cursor-pointer has-[:checked]:bg-primary/10 has-[:checked]:border-primary flex-1"><RadioGroupItem value="custom" /><span>Usar Galeria Customizada</span></Label><Label className={cn("flex items-center space-x-2 p-3 border rounded-md cursor-pointer has-[:checked]:bg-primary/10 has-[:checked]:border-primary flex-1", linkedAssetsDetails.length === 0 && "cursor-not-allowed opacity-50")}><RadioGroupItem value={linkedAssetsDetails[0]?.id || ''} disabled={linkedAssetsDetails.length === 0} /><span>Herdar de um Bem Vinculado</span></Label></RadioGroup></FormControl></FormItem>)}/>
+                         <FormField control={controlAny} name="inheritedMediaFromAssetId" render={({ field }) => (<FormItem className="space-y-3 p-4 border rounded-md bg-background" data-ai-id="lot-form-media-source"><FormLabel className="text-base font-semibold">Fonte da Galeria de Imagens</FormLabel><FormControl><RadioGroup onValueChange={(value) => field.onChange(value === "custom" ? null : value)} value={field.value ? field.value : "custom"} className="flex flex-col sm:flex-row gap-4" data-ai-id="lot-form-media-source-group"><Label className="flex items-center space-x-2 p-3 border rounded-md cursor-pointer has-[:checked]:bg-primary/10 has-[:checked]:border-primary flex-1" data-ai-id="lot-form-media-source-custom"><RadioGroupItem value="custom" /><span>Usar Galeria Customizada</span></Label><Label className={cn("flex items-center space-x-2 p-3 border rounded-md cursor-pointer has-[:checked]:bg-primary/10 has-[:checked]:border-primary flex-1", linkedAssetsDetails.length === 0 && "cursor-not-allowed opacity-50")} data-ai-id="lot-form-media-source-inherit"><RadioGroupItem value={linkedAssetsDetails[0]?.id || ''} disabled={linkedAssetsDetails.length === 0} /><span>Herdar de um Bem Vinculado</span></Label></RadioGroup></FormControl></FormItem>)}/>
                           {inheritedMediaFromAssetId && (<FormField control={controlAny} name="inheritedMediaFromAssetId" render={({ field }) => (<FormItem><FormLabel>Selecione o Bem para Herdar a Galeria</FormLabel><EntitySelector value={field.value} onChange={field.onChange} options={linkedAssetsDetails.map(b => ({value: b.id, label: b.title}))} placeholder="Selecione um bem" searchPlaceholder="Buscar bem..." emptyStateMessage="Nenhum bem vinculado para selecionar."/><FormMessage /></FormItem>)} />)}
                           <fieldset disabled={!!inheritedMediaFromAssetId} className="space-y-4 group">
                               <FormItem><FormLabel>Imagem Principal</FormLabel><div className="flex items-center gap-4"><div className="relative w-24 h-24 flex-shrink-0 bg-muted rounded-md overflow-hidden border">{isValidImageUrl(displayImageUrl) ? (<Image src={displayImageUrl ?? ''} alt="Prévia" fill className="object-contain" />) : (<ImageIcon className="h-8 w-8 text-muted-foreground m-auto"/>)}</div><div className="space-y-2 flex-grow"><Button type="button" variant="outline" onClick={() => setIsMainImageDialogOpen(true)} className="group-disabled:cursor-not-allowed">{imageUrlPreview ? 'Alterar Imagem' : 'Escolher da Biblioteca'}</Button><FormField control={controlAny} name="imageUrl" render={({ field }) => (<FormControl><Input type="url" placeholder="Ou cole a URL aqui" {...field} value={field.value ?? ""} /></FormControl>)} /><FormMessage /></div></div></FormItem>

--- a/src/services/asset.service.ts
+++ b/src/services/asset.service.ts
@@ -169,12 +169,16 @@ export class AssetService {
       // Gera o publicId usando a máscara configurada
       const publicId = await generatePublicId(tenantId, 'asset');
 
+      const safeMediaIds = Array.isArray(mediaItemIds)
+        ? Array.from(new Set(mediaItemIds.filter((mediaId) => mediaId !== null && mediaId !== undefined && mediaId !== '')))
+        : [];
+
       const dataToCreate: Prisma.AssetCreateInput = {
         title: assetData.title,
         ...normalizedAssetData,
         publicId,
         Tenant: { connect: { id: BigInt(tenantId) } },
-        mediaItemIds: mediaItemIds ? (mediaItemIds as any) : undefined, // Save to JSON field as well
+        mediaItemIds: safeMediaIds.length > 0 ? (safeMediaIds as any) : undefined, // Save to JSON field as well
       };
 
       // Conecta relacionamentos
@@ -200,8 +204,7 @@ export class AssetService {
           const asset = await tx.asset.create({ data: dataToCreate });
 
           // Create AssetMedia records if mediaItemIds are present
-              if (mediaItemIds && Array.isArray(mediaItemIds) && mediaItemIds.length > 0) {
-                const safeMediaIds = mediaItemIds.filter((mediaId) => mediaId !== null && mediaId !== undefined && mediaId !== '');
+              if (safeMediaIds.length > 0) {
                 await Promise.all((safeMediaIds as Array<string | number | bigint>).map((mediaId, index) => {
                   return tx.assetMedia.create({
                     data: {
@@ -235,6 +238,7 @@ export class AssetService {
       const { 
         categoryId, subcategoryId, judicialProcessId, sellerId, cityId, stateId, 
         street, number, complement, neighborhood, zipCode,
+        mediaItemIds,
         imageMediaId, occupationUpdatedBy,
         ...assetData 
       } = data;
@@ -262,13 +266,26 @@ export class AssetService {
       });
 
       const dataToUpdate: Prisma.AssetUpdateInput = { ...normalizedAssetData };
+
+      const safeMediaIds = Array.isArray(mediaItemIds)
+        ? Array.from(new Set(mediaItemIds.filter((mediaId) => mediaId !== null && mediaId !== undefined && mediaId !== '')))
+        : undefined;
       
       // Conecta relacionamentos
       if (categoryId) (dataToUpdate as any).LotCategory = { connect: { id: BigInt(categoryId) } };
       if (subcategoryId) (dataToUpdate as any).Subcategory = { connect: { id: BigInt(subcategoryId) } };
       if (judicialProcessId) (dataToUpdate as any).JudicialProcess = { connect: { id: BigInt(judicialProcessId) } };
       if (sellerId) (dataToUpdate as any).Seller = { connect: { id: BigInt(sellerId) } };
-      if (imageMediaId) (dataToUpdate as any).CoverImage = { connect: { id: BigInt(imageMediaId) } };
+      if (imageMediaId !== undefined) {
+        if (imageMediaId) {
+          (dataToUpdate as any).CoverImage = { connect: { id: BigInt(imageMediaId) } };
+        } else {
+          (dataToUpdate as any).CoverImage = { disconnect: true };
+        }
+      }
+      if (safeMediaIds !== undefined) {
+        (dataToUpdate as any).mediaItemIds = safeMediaIds as any;
+      }
       if (occupationUpdatedBy) (dataToUpdate as any).User = { connect: { id: BigInt(occupationUpdatedBy) } };
       
       // Atualiza locationCity e locationState baseado nos IDs se fornecidos
@@ -281,7 +298,31 @@ export class AssetService {
           if(state) dataToUpdate.locationState = state.uf;
       }
 
-      await this.repository.update(id, dataToUpdate);
+      const updatedAsset = await this.repository.update(id, dataToUpdate);
+
+      if (safeMediaIds !== undefined) {
+        const updatedAssetId = typeof (updatedAsset as any).id === 'bigint'
+          ? (updatedAsset as any).id
+          : BigInt((updatedAsset as any).id);
+        const updatedTenantId = typeof (updatedAsset as any).tenantId === 'bigint'
+          ? (updatedAsset as any).tenantId
+          : BigInt((updatedAsset as any).tenantId);
+
+        await this.prisma.assetMedia.deleteMany({ where: { assetId: updatedAssetId } });
+
+        if (safeMediaIds.length > 0) {
+          await this.prisma.assetMedia.createMany({
+            data: safeMediaIds.map((mediaId, index) => ({
+              assetId: updatedAssetId,
+              tenantId: updatedTenantId,
+              mediaItemId: BigInt(mediaId),
+              displayOrder: index,
+              isPrimary: index === 0,
+            })),
+          });
+        }
+      }
+
       return { success: true, message: 'Ativo atualizado com sucesso.' };
     } catch (error: any) {
       console.error(`Error in AssetService.updateAsset for id ${id}:`, error);

--- a/src/services/lot.service.ts
+++ b/src/services/lot.service.ts
@@ -382,6 +382,65 @@ export class LotService {
     return lotRecord.id;
   }
 
+  private parseJsonStringArray(value: unknown): string[] {
+    if (!Array.isArray(value)) return [];
+    return Array.from(
+      new Set(
+        value
+          .map((item) => (item === null || item === undefined ? '' : String(item).trim()))
+          .filter((item) => item.length > 0)
+      )
+    );
+  }
+
+  private async resolveInheritedMediaPayloadFromAsset(
+    inheritedMediaFromAssetId: string,
+    tenantId: bigint
+  ): Promise<{ success: true; payload: { imageUrl: string | null; imageMediaId: bigint | null; galleryImageUrls: string[]; mediaItemIds: string[] } } | { success: false; message: string }> {
+    const assetWhereClause = /^\d+$/.test(inheritedMediaFromAssetId)
+      ? { id: BigInt(inheritedMediaFromAssetId) }
+      : { publicId: inheritedMediaFromAssetId };
+
+    const sourceAsset = await this.prisma.asset.findFirst({
+      where: {
+        ...assetWhereClause,
+        tenantId,
+      },
+      include: {
+        AssetMedia: {
+          include: { MediaItem: true },
+          orderBy: { displayOrder: 'asc' },
+        },
+      },
+    });
+
+    if (!sourceAsset) {
+      return { success: false, message: 'O bem selecionado para herdar mídia não foi encontrado no tenant atual.' };
+    }
+
+    const galleryFromJson = this.parseJsonStringArray(sourceAsset.galleryImageUrls);
+    const galleryFromRelation = sourceAsset.AssetMedia
+      .map((assetMedia) => assetMedia.MediaItem?.urlOriginal)
+      .filter((url): url is string => typeof url === 'string' && url.trim().length > 0);
+    const inheritedGalleryUrls = Array.from(new Set([...galleryFromJson, ...galleryFromRelation]));
+
+    const mediaIdsFromJson = this.parseJsonStringArray(sourceAsset.mediaItemIds);
+    const mediaIdsFromRelation = sourceAsset.AssetMedia.map((assetMedia) => assetMedia.mediaItemId.toString());
+    const inheritedMediaIds = Array.from(new Set([...mediaIdsFromJson, ...mediaIdsFromRelation]));
+
+    const inheritedImageUrl = sourceAsset.imageUrl || inheritedGalleryUrls[0] || null;
+
+    return {
+      success: true,
+      payload: {
+        imageUrl: inheritedImageUrl,
+        imageMediaId: sourceAsset.imageMediaId ? BigInt(sourceAsset.imageMediaId.toString()) : null,
+        galleryImageUrls: inheritedGalleryUrls,
+        mediaItemIds: inheritedMediaIds,
+      },
+    };
+  }
+
   private mapLotWithDetails(lot: any): Lot {
     const primaryProcess = lot.JudicialProcess?.[0] ?? lot.judicialProcesses?.[0];
     const lotAuction = lot.Auction ?? lot.auction;
@@ -405,11 +464,13 @@ export class LotService {
     // Gallery Mapping Logic
     let galleryImageUrls: string[] = [];
     if (Array.isArray(lot.galleryImageUrls)) {
-        galleryImageUrls = [...lot.galleryImageUrls];
+      galleryImageUrls = [...lot.galleryImageUrls];
     }
-    
-    // If we have AssetsOnLots with deeply nested Media, use them
-    if (assetsOnLots) {
+
+    const shouldFallbackToAssets = galleryImageUrls.length === 0 && !imageUrl;
+
+    // Fallback for legacy lots without own gallery: derive from linked assets
+    if (shouldFallbackToAssets && assetsOnLots) {
         assetsOnLots.forEach((assetLink: any) => {
             const asset = assetLink.Asset ?? assetLink.asset;
             if (asset && Array.isArray(asset.AssetMedia)) {
@@ -759,6 +820,7 @@ export class LotService {
       const { 
         assetIds = [],
         lotRisks = [],
+        inheritedMediaFromAssetId,
         ...cleanData 
       } = data as any;
 
@@ -775,6 +837,30 @@ export class LotService {
           createdAt: new Date(),
           updatedAt: new Date(),
       };
+
+      if (inheritedMediaFromAssetId) {
+        const inheritedMedia = await this.resolveInheritedMediaPayloadFromAsset(
+          String(inheritedMediaFromAssetId),
+          BigInt(tenantId)
+        );
+
+        if (!inheritedMedia.success) {
+          return { success: false, message: inheritedMedia.message };
+        }
+
+        createData.imageUrl = inheritedMedia.payload.imageUrl;
+        createData.imageMediaId = inheritedMedia.payload.imageMediaId;
+        createData.galleryImageUrls = inheritedMedia.payload.galleryImageUrls;
+        createData.mediaItemIds = inheritedMedia.payload.mediaItemIds;
+      }
+
+      if (createData.imageMediaId !== undefined) {
+        if (createData.imageMediaId === '' || createData.imageMediaId === null) {
+          createData.imageMediaId = null;
+        } else {
+          createData.imageMediaId = BigInt(String(createData.imageMediaId));
+        }
+      }
 
       // Strip phantom fields that don't exist on the Prisma Lot model
       const phantomLotFields = [
@@ -942,6 +1028,7 @@ export class LotService {
         assetIds = [],
         auctionId,
         lotRisks,
+        inheritedMediaFromAssetId,
         ...cleanData 
       } = data as any;
 
@@ -950,6 +1037,30 @@ export class LotService {
           success: false,
           message: 'Não é possível alterar bens vinculados após a abertura para lances/resultados do lote.',
         };
+      }
+
+      if (inheritedMediaFromAssetId) {
+        const inheritedMedia = await this.resolveInheritedMediaPayloadFromAsset(
+          String(inheritedMediaFromAssetId),
+          tenantForLot
+        );
+
+        if (!inheritedMedia.success) {
+          return { success: false, message: inheritedMedia.message };
+        }
+
+        cleanData.imageUrl = inheritedMedia.payload.imageUrl;
+        cleanData.imageMediaId = inheritedMedia.payload.imageMediaId;
+        cleanData.galleryImageUrls = inheritedMedia.payload.galleryImageUrls;
+        cleanData.mediaItemIds = inheritedMedia.payload.mediaItemIds;
+      }
+
+      if (cleanData.imageMediaId !== undefined) {
+        if (cleanData.imageMediaId === '' || cleanData.imageMediaId === null) {
+          cleanData.imageMediaId = null;
+        } else {
+          cleanData.imageMediaId = BigInt(String(cleanData.imageMediaId));
+        }
       }
 
       // Strip phantom fields that don't exist on the Prisma Lot model

--- a/tests/e2e/admin/lot-media-inheritance-ui.spec.ts
+++ b/tests/e2e/admin/lot-media-inheritance-ui.spec.ts
@@ -1,0 +1,52 @@
+/**
+ * @fileoverview E2E de regressão para configuração de mídia entre ativo e lote no admin.
+ * BDD:
+ * - Given admin autenticado
+ * - When abre formulários de ativo/lote
+ * - Then controles de galeria e origem da mídia ficam disponíveis para operação
+ */
+import { test, expect } from '@playwright/test';
+import { loginAsAdmin } from '../helpers/auth-helper';
+
+const BASE_URL = process.env.BASE_URL || 'http://demo.localhost:9011';
+
+async function gotoAdminRoute(page: import('@playwright/test').Page, path: '/admin/assets/new' | '/admin/lots/new') {
+  const targetUrl = `${BASE_URL}${path}`;
+
+  for (let attempt = 1; attempt <= 3; attempt += 1) {
+    await page.goto(targetUrl, { waitUntil: 'domcontentloaded' });
+
+    if (!page.url().includes('/auth/login')) {
+      return;
+    }
+
+    await loginAsAdmin(page, BASE_URL);
+  }
+
+  throw new Error(`Nao foi possivel autenticar para acessar ${path}`);
+}
+
+test.describe('Admin lot media inheritance UI', () => {
+  test.beforeEach(async ({ page }, testInfo) => {
+    test.skip(/noauth/i.test(testInfo.project.name), 'Fluxo administrativo exige sessão autenticada.');
+  });
+
+  test('asset form shows gallery controls', async ({ page }) => {
+    await gotoAdminRoute(page, '/admin/assets/new');
+
+    await expect(page.locator('[data-ai-id="asset-form"]')).toBeVisible();
+    await expect(page.locator('[data-ai-id="asset-gallery-card"]')).toBeVisible();
+    await expect(page.locator('[data-ai-id="asset-gallery-open-library-button"]')).toBeVisible();
+    await expect(page.locator('[data-ai-id="asset-gallery-empty-state"]')).toContainText('Nenhuma imagem na galeria');
+  });
+
+  test('lot form shows media source mode toggle', async ({ page }) => {
+    await gotoAdminRoute(page, '/admin/lots/new');
+
+    await expect(page.locator('[data-ai-id="lot-form"]')).toBeVisible();
+    await expect(page.locator('[data-ai-id="lot-form-media-section"]')).toBeVisible();
+    await expect(page.locator('[data-ai-id="lot-form-media-source-custom"]')).toContainText('Usar Galeria Customizada');
+    await expect(page.locator('[data-ai-id="lot-form-media-source-inherit"]')).toContainText('Herdar de um Bem Vinculado');
+    await expect(page.getByRole('button', { name: 'Adicionar à Galeria' })).toBeEnabled();
+  });
+});

--- a/tests/e2e/helpers/auth-helper.ts
+++ b/tests/e2e/helpers/auth-helper.ts
@@ -267,11 +267,13 @@ export async function loginAs(
     customTenant?: string | RegExp;
     waitPattern?: RegExp;
     timeout?: number;
+    fallbackPath?: string;
   } = {},
 ): Promise<string[]> {
   const cred = CREDENTIALS[role];
   const timeout = options.timeout ?? 60_000;
   const waitPattern = options.waitPattern ?? /\/(admin|dashboard|lawyer|home)/i;
+  const fallbackPath = options.fallbackPath ?? '/dashboard/overview';
   const consoleErrors: string[] = [];
 
   // Browser console telemetry routed to Node.js stdout
@@ -440,9 +442,9 @@ export async function loginAs(
       throw new Error(`Login failed with page error: ${pageState.error}`);
     }
 
-    // Session should be valid — navigate directly to dashboard
-    console.log('[loginAs] Navigating manually to /dashboard/overview ...');
-    await page.goto(`${baseUrl}/dashboard/overview`, { waitUntil: 'domcontentloaded', timeout: 60_000 });
+    // Session should be valid — navigate directly to fallback path
+    console.log(`[loginAs] Navigating manually to ${fallbackPath} ...`);
+    await page.goto(`${baseUrl}${fallbackPath}`, { waitUntil: 'domcontentloaded', timeout: 60_000 });
 
     const afterUrl = page.url();
     if (afterUrl.includes('/auth/login') || afterUrl.includes('/auth/')) {
@@ -463,7 +465,8 @@ export async function loginAs(
  */
 export async function loginAsAdmin(page: Page, baseUrl: string): Promise<string[]> {
   return loginAs(page, 'admin', baseUrl, {
-    waitPattern: /\/(admin|dashboard)/i,
+    waitPattern: /\/admin/i,
+    fallbackPath: '/admin',
   });
 }
 

--- a/tests/itsm/features/lot-media-inheritance.feature
+++ b/tests/itsm/features/lot-media-inheritance.feature
@@ -1,0 +1,22 @@
+Feature: Herança opcional de galeria entre ativo e lote
+  Como pessoa administradora
+  Quero cadastrar galeria de fotos no ativo e decidir no lote se herdo ou customizo
+  Para manter flexibilidade de mídia sem misturar fontes de forma involuntária
+
+  Scenario: Cadastro de ativo com galeria persistível
+    Given que estou no formulário administrativo de ativos
+    When adiciono imagem principal e imagens na galeria pela biblioteca de mídia
+    Then o ativo persiste imageMediaId e mediaItemIds da galeria
+    And as miniaturas da galeria ficam visíveis no formulário
+
+  Scenario: Lote herda galeria de ativo vinculado
+    Given que o lote possui um ativo vinculado com galeria preenchida
+    When escolho herdar a galeria do ativo no formulário de lote
+    Then o payload do lote recebe imagem principal e galeria do ativo selecionado
+    And o detalhe público do lote exibe a mídia herdada
+
+  Scenario: Lote usa galeria própria sem misturar fallback do ativo
+    Given que o lote possui imagem ou galeria customizada
+    When salvo o lote em modo de galeria customizada
+    Then o serviço prioriza a mídia do próprio lote
+    And a galeria do ativo vinculado não é mesclada automaticamente

--- a/tests/unit/lot-service-media-inheritance.spec.ts
+++ b/tests/unit/lot-service-media-inheritance.spec.ts
@@ -1,0 +1,168 @@
+/**
+ * @fileoverview Testes unitários para herança opcional de galeria de ativos no LotService.
+ * Garante que, quando `inheritedMediaFromAssetId` é informado, o lote persiste mídia
+ * derivada do ativo de origem sem depender de campo adicional no schema do lote.
+ * @vitest-environment node
+ */
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+
+vi.mock('@/lib/public-id-generator', () => ({
+  generatePublicId: vi.fn().mockResolvedValue('LOT-TEST-001'),
+}));
+
+vi.mock('@/lib/prisma', () => {
+  const lotMock = {
+    findUnique: vi.fn(),
+    create: vi.fn(),
+    update: vi.fn(),
+  };
+
+  const assetMock = {
+    findFirst: vi.fn(),
+    updateMany: vi.fn(),
+  };
+
+  const assetsOnLotsMock = {
+    findMany: vi.fn(),
+    deleteMany: vi.fn(),
+    createMany: vi.fn(),
+  };
+
+  const txAny = {
+    lot: lotMock,
+    asset: assetMock,
+    assetsOnLots: assetsOnLotsMock,
+    lotRisk: {
+      deleteMany: vi.fn(),
+      createMany: vi.fn(),
+    },
+  } as any;
+
+  const prismaMock: any = {
+    lot: lotMock,
+    asset: assetMock,
+    assetsOnLots: assetsOnLotsMock,
+    lotRisk: txAny.lotRisk,
+    $transaction: vi.fn(async (fn: (tx: any) => Promise<any>) => fn(txAny)),
+  };
+
+  return {
+    prisma: prismaMock,
+    default: prismaMock,
+  };
+});
+
+import { prisma as mockedPrisma } from '@/lib/prisma';
+import { LotService } from '@/services/lot.service';
+
+describe('LotService media inheritance', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    mockedPrisma.assetsOnLots.findMany.mockResolvedValue([]);
+    mockedPrisma.assetsOnLots.deleteMany.mockResolvedValue({ count: 0 });
+    mockedPrisma.assetsOnLots.createMany.mockResolvedValue({ count: 0 });
+    mockedPrisma.lotRisk.deleteMany.mockResolvedValue({ count: 0 });
+    mockedPrisma.lotRisk.createMany.mockResolvedValue({ count: 0 });
+  });
+
+  it('aplica galeria do ativo ao criar lote quando herança é selecionada', async () => {
+    mockedPrisma.asset.findFirst.mockResolvedValue({
+      id: 55n,
+      tenantId: 7n,
+      imageUrl: 'https://cdn.exemplo.com/assets/55-main.jpg',
+      imageMediaId: 900n,
+      galleryImageUrls: ['https://cdn.exemplo.com/assets/55-gallery-1.jpg'],
+      mediaItemIds: ['900', '901'],
+      AssetMedia: [
+        { mediaItemId: 900n, displayOrder: 0, MediaItem: { urlOriginal: 'https://cdn.exemplo.com/assets/55-gallery-1.jpg' } },
+        { mediaItemId: 902n, displayOrder: 1, MediaItem: { urlOriginal: 'https://cdn.exemplo.com/assets/55-gallery-2.jpg' } },
+      ],
+    });
+
+    mockedPrisma.lot.create.mockResolvedValue({ id: 321n });
+
+    const service = new LotService();
+    const result = await service.createLot(
+      {
+        title: 'Lote de teste com herança',
+        auctionId: '11',
+        type: 'VEICULO',
+        price: 1000,
+        inheritedMediaFromAssetId: '55',
+      } as any,
+      '7'
+    );
+
+    expect(result.success).toBe(true);
+    expect(mockedPrisma.asset.findFirst).toHaveBeenCalledWith(
+      expect.objectContaining({
+        where: expect.objectContaining({ id: 55n, tenantId: 7n }),
+      })
+    );
+
+    expect(mockedPrisma.lot.create).toHaveBeenCalledWith(
+      expect.objectContaining({
+        data: expect.objectContaining({
+          imageUrl: 'https://cdn.exemplo.com/assets/55-main.jpg',
+          imageMediaId: 900n,
+          galleryImageUrls: [
+            'https://cdn.exemplo.com/assets/55-gallery-1.jpg',
+            'https://cdn.exemplo.com/assets/55-gallery-2.jpg',
+          ],
+          mediaItemIds: ['900', '901', '902'],
+        }),
+      })
+    );
+  });
+
+  it('atualiza mídia do lote com base no ativo herdado durante update', async () => {
+    mockedPrisma.lot.findUnique
+      .mockResolvedValueOnce({
+        id: 123n,
+        status: 'RASCUNHO',
+        Auction: { status: 'RASCUNHO', title: 'Leilão Teste' },
+      })
+      .mockResolvedValueOnce({
+        tenantId: 7n,
+        status: 'RASCUNHO',
+      });
+
+    mockedPrisma.asset.findFirst.mockResolvedValue({
+      id: 88n,
+      tenantId: 7n,
+      imageUrl: null,
+      imageMediaId: null,
+      galleryImageUrls: ['https://cdn.exemplo.com/assets/88-gallery-1.jpg'],
+      mediaItemIds: ['700'],
+      AssetMedia: [
+        { mediaItemId: 701n, displayOrder: 1, MediaItem: { urlOriginal: 'https://cdn.exemplo.com/assets/88-gallery-2.jpg' } },
+      ],
+    });
+
+    mockedPrisma.lot.update.mockResolvedValue({ id: 123n });
+
+    const service = new LotService();
+    const result = await service.updateLot('123', {
+      title: 'Lote Atualizado',
+      inheritedMediaFromAssetId: '88',
+      assetIds: [],
+    } as any);
+
+    expect(result.success).toBe(true);
+    expect(mockedPrisma.lot.update).toHaveBeenCalledWith(
+      expect.objectContaining({
+        where: { id: 123n },
+        data: expect.objectContaining({
+          title: 'Lote Atualizado',
+          imageUrl: 'https://cdn.exemplo.com/assets/88-gallery-1.jpg',
+          imageMediaId: null,
+          galleryImageUrls: [
+            'https://cdn.exemplo.com/assets/88-gallery-1.jpg',
+            'https://cdn.exemplo.com/assets/88-gallery-2.jpg',
+          ],
+          mediaItemIds: ['700', '701'],
+        }),
+      })
+    );
+  });
+});


### PR DESCRIPTION
## Resumo\n- adiciona galeria de fotos no cadastro/edição de ativo (seleção múltipla, deduplicação e remoção)\n- implementa herança opcional de mídia do ativo para o lote com fallback seguro\n- mantém prioridade da mídia própria do lote sobre mídia herdada\n- adiciona testes unitários, BDD e E2E para o fluxo\n\n## Testes executados\n- npm run typecheck\n- npm run test:unit -- tests/unit/lot-service-media-inheritance.spec.ts\n- npx playwright test tests/e2e/admin/lot-media-inheritance-ui.spec.ts --config=playwright.autofix.config.ts --project=chromium-autofix\n\n## Evidências\n- Execução local Playwright focal: 2 passed\n