### PR TITLE
fix: restore admin global search flow

### DIFF
--- a/src/app/actions/global-search.ts
+++ b/src/app/actions/global-search.ts
@@ -1,6 +1,47 @@
 'use server';
 
 import { prisma } from '@/lib/prisma';
+import { getTenantIdFromRequest } from '@/lib/actions/auth';
+import { insensitiveContains } from '@/lib/prisma/query-helpers';
+
+const MIN_QUERY_LENGTH = 2;
+const RESULTS_PER_ENTITY = 6;
+const MAX_TOTAL_RESULTS = 15;
+
+const toBigIntOrNull = (value: string): bigint | null => {
+  if (!/^\d+$/.test(value)) {
+    return null;
+  }
+
+  try {
+    return BigInt(value);
+  } catch {
+    return null;
+  }
+};
+
+const scoreMatch = (result: SearchResultItem, normalizedQuery: string): number => {
+  const title = result.title.toLowerCase();
+  if (title === normalizedQuery) {
+    return 0;
+  }
+  if (title.startsWith(normalizedQuery)) {
+    return 1;
+  }
+  if (title.includes(normalizedQuery)) {
+    return 2;
+  }
+
+  const subtitle = (result.subtitle ?? '').toLowerCase();
+  if (subtitle.startsWith(normalizedQuery)) {
+    return 3;
+  }
+  if (subtitle.includes(normalizedQuery)) {
+    return 4;
+  }
+
+  return 5;
+};
 
 export type SearchResultItem = {
   id: string;
@@ -11,42 +52,62 @@ export type SearchResultItem = {
 };
 
 export async function globalSearch(query: string): Promise<SearchResultItem[]> {
-  if (!query || query.length < 2) {
+  const normalizedQuery = query.trim();
+  if (!normalizedQuery || normalizedQuery.length < MIN_QUERY_LENGTH) {
     return [];
   }
 
-  const lowerQuery = query.toLowerCase();
+  const tenantId = BigInt(await getTenantIdFromRequest(false));
+  const numericQuery = toBigIntOrNull(normalizedQuery);
 
   const [auctions, lots, users] = await Promise.all([
     prisma.auction.findMany({
       where: {
+        tenantId,
         OR: [
-          { title: { contains: query } }, // Case-insensitive by default in MySQL/Prisma usually, but depends on collation
-          { description: { contains: query } },
+          { title: insensitiveContains(normalizedQuery) },
+          { description: insensitiveContains(normalizedQuery) },
+          { publicId: insensitiveContains(normalizedQuery) },
+          { slug: insensitiveContains(normalizedQuery) },
+          ...(numericQuery ? [{ id: numericQuery }] : []),
         ],
       },
-      take: 5,
-      select: { id: true, title: true, description: true },
+      take: RESULTS_PER_ENTITY,
+      orderBy: { updatedAt: 'desc' },
+      select: { id: true, publicId: true, title: true, status: true },
     }),
     prisma.lot.findMany({
       where: {
+        tenantId,
         OR: [
-          { title: { contains: query } },
-          { number: { contains: query } },
-          { description: { contains: query } },
+          { title: insensitiveContains(normalizedQuery) },
+          { number: insensitiveContains(normalizedQuery) },
+          { description: insensitiveContains(normalizedQuery) },
+          { publicId: insensitiveContains(normalizedQuery) },
+          { slug: insensitiveContains(normalizedQuery) },
+          ...(numericQuery ? [{ id: numericQuery }] : []),
         ],
       },
-      take: 5,
-      select: { id: true, title: true, number: true, auctionId: true },
+      take: RESULTS_PER_ENTITY,
+      orderBy: { updatedAt: 'desc' },
+      select: { id: true, publicId: true, title: true, number: true, status: true },
     }),
     prisma.user.findMany({
       where: {
+        UsersOnTenants: {
+          some: {
+            tenantId,
+          },
+        },
         OR: [
-          { fullName: { contains: query } },
-          { email: { contains: query } },
+          { fullName: insensitiveContains(normalizedQuery) },
+          { email: insensitiveContains(normalizedQuery) },
+          { cpf: insensitiveContains(normalizedQuery) },
+          ...(numericQuery ? [{ id: numericQuery }] : []),
         ],
       },
-      take: 5,
+      take: RESULTS_PER_ENTITY,
+      orderBy: { updatedAt: 'desc' },
       select: { id: true, fullName: true, email: true },
     }),
   ]);
@@ -54,22 +115,25 @@ export async function globalSearch(query: string): Promise<SearchResultItem[]> {
   const results: SearchResultItem[] = [];
 
   auctions.forEach((auction) => {
+    const auctionIdentifier = auction.publicId ?? auction.id.toString();
     results.push({
       id: auction.id.toString(),
       type: 'auction',
       title: auction.title,
-      subtitle: 'Leilão',
-      url: `/admin/auctions/${auction.id}`,
+      subtitle: `Leilao ${auctionIdentifier} - ${auction.status}`,
+      url: `/admin/auctions/${auctionIdentifier}/edit`,
     });
   });
 
   lots.forEach((lot) => {
+    const lotIdentifier = lot.publicId ?? lot.id.toString();
+    const lotLabel = lot.number ? `Lote #${lot.number}` : `Lote ${lotIdentifier}`;
     results.push({
       id: lot.id.toString(),
       type: 'lot',
       title: lot.title,
-      subtitle: `Lote #${lot.number || ''}`,
-      url: `/admin/lots/${lot.id}`, // Assuming this route exists
+      subtitle: `${lotLabel} - ${lot.status}`,
+      url: `/admin/lots/${lotIdentifier}/edit`,
     });
   });
 
@@ -79,9 +143,11 @@ export async function globalSearch(query: string): Promise<SearchResultItem[]> {
       type: 'user',
       title: user.fullName || user.email,
       subtitle: user.email,
-      url: `/admin/users/${user.id}`,
+      url: `/admin-plus/users/${user.id.toString()}`,
     });
   });
 
-  return results;
+  return results
+    .sort((a, b) => scoreMatch(a, normalizedQuery.toLowerCase()) - scoreMatch(b, normalizedQuery.toLowerCase()))
+    .slice(0, MAX_TOTAL_RESULTS);
 }

--- a/src/app/admin/admin-layout.client.tsx
+++ b/src/app/admin/admin-layout.client.tsx
@@ -12,6 +12,7 @@ import { WidgetPreferencesProvider } from '@/contexts/widget-preferences-context
 import WidgetConfigurationModal from '@/components/admin/dashboard/WidgetConfigurationModal';
 import { ThemeProvider } from '@/components/theme-provider';
 import dynamic from 'next/dynamic';
+import CommandPalette from '@/components/layout/command-palette';
 
 // Lazy-load query monitor so it doesn't affect the bundle when disabled
 const AdminQueryMonitor = dynamic(() => import('@/components/support/admin-query-monitor'), { ssr: false });
@@ -149,6 +150,10 @@ export function AdminLayoutClient({ children }: AdminLayoutClientProps) {
         <WidgetConfigurationModal
           isOpen={isWidgetConfigModalOpen}
           onClose={() => setIsWidgetConfigModalOpen(false)}
+        />
+        <CommandPalette
+          isOpen={isCommandPaletteOpen}
+          onOpenChange={setCommandPaletteOpen}
         />
       </WidgetPreferencesProvider>
     </ThemeProvider>

--- a/src/components/layout/admin-header.tsx
+++ b/src/components/layout/admin-header.tsx
@@ -14,6 +14,7 @@ import Link from 'next/link';
 import { Badge } from '../ui/badge';
 import { TooltipProvider, Tooltip, TooltipTrigger, TooltipContent } from '../ui/tooltip';
 import { ThemeToggle } from './theme-toggle';
+import { useMemo } from 'react';
 
 interface AdminHeaderProps {
   onSearchClick: () => void;
@@ -31,6 +32,13 @@ export default function AdminHeader({
   onQueryMonitorToggle
 }: AdminHeaderProps) {
   const { unreadNotificationsCount } = useAuth();
+  const keyboardShortcutLabel = useMemo(() => {
+    if (typeof navigator === 'undefined') {
+      return 'Ctrl+K';
+    }
+
+    return /Mac|iPhone|iPad|iPod/i.test(navigator.platform) ? 'Cmd+K' : 'Ctrl+K';
+  }, []);
 
   return (
     <header className="header-admin-sticky" data-ai-id="admin-header-main">
@@ -52,7 +60,7 @@ export default function AdminHeader({
             <Search className="icon-admin-search" />
             <span className="text-admin-search-placeholder">Buscar leilões, lotes...</span>
             <kbd className="kbd-admin-search" data-ai-id="admin-header-kbd">
-              <span className="text-kbd-symbol">⌘</span>K
+              {keyboardShortcutLabel}
             </kbd>
           </Button>
       </div>

--- a/tests/e2e/admin/admin-global-search.spec.ts
+++ b/tests/e2e/admin/admin-global-search.spec.ts
@@ -1,0 +1,32 @@
+import { test, expect } from '@playwright/test';
+import { loginAsAdmin } from '../helpers/auth-helper';
+
+const PORT = process.env.PORT || '9006';
+const BASE_URL = process.env.PLAYWRIGHT_BASE_URL || `http://demo.localhost:${PORT}`;
+
+test.describe('Admin global search', () => {
+  test.setTimeout(120000);
+
+  test('opens via header and navigates immediately after selecting a result', async ({ page }) => {
+    await loginAsAdmin(page, BASE_URL);
+    await page.goto(`${BASE_URL}/admin/dashboard`, { waitUntil: 'domcontentloaded', timeout: 60000 });
+
+    const searchButton = page.locator('[data-ai-id="admin-header-search-button"]');
+    await expect(searchButton).toBeVisible({ timeout: 60000 });
+    await expect(page.locator('[data-ai-id="admin-header-kbd"]')).toContainText(/Ctrl\+K|Cmd\+K/);
+
+    await searchButton.click();
+
+    const commandInput = page.locator('input[cmdk-input]');
+    await expect(commandInput).toBeVisible({ timeout: 10000 });
+
+    await commandInput.fill('Lotes');
+
+    const lotesNavItem = page.locator('[data-ai-id="cmd-nav-lotes"]');
+    await expect(lotesNavItem).toBeVisible({ timeout: 10000 });
+    await commandInput.press('ArrowDown');
+    await commandInput.press('Enter');
+
+    await expect(page).toHaveURL(new RegExp('/admin/lots'));
+  });
+});

--- a/tests/itsm/features/admin-global-search.feature
+++ b/tests/itsm/features/admin-global-search.feature
@@ -1,0 +1,16 @@
+Feature: Busca global no header do Admin
+  Como pessoa administradora
+  Quero buscar entidades direto no header com atalho de teclado
+  Para abrir rapidamente a pagina de edicao ou detalhe do resultado
+
+  Scenario: Abrir busca e redirecionar para o resultado selecionado
+    Given que estou autenticado no painel administrativo
+    When abro a busca global pelo botao do header ou atalho de teclado
+    And digito um termo de busca de leilao, lote ou usuario
+    Then devo visualizar resultados da busca global
+    And ao selecionar um resultado devo ser redirecionado imediatamente para a pagina de edicao ou detalhe correspondente
+
+  Scenario: Hint de atalho deve ser contextual por sistema operacional
+    Given que estou no header do admin
+    When visualizo o hint de teclado da busca
+    Then o hint deve exibir Ctrl+K em Windows/Linux e Cmd+K em macOS

--- a/tests/unit/admin-global-search.spec.ts
+++ b/tests/unit/admin-global-search.spec.ts
@@ -1,0 +1,109 @@
+/**
+ * @fileoverview Validates admin global search mapping, tenant scoping, and destination URLs.
+ */
+
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+
+const mockAuctionFindMany = vi.fn();
+const mockLotFindMany = vi.fn();
+const mockUserFindMany = vi.fn();
+const mockGetTenantIdFromRequest = vi.fn();
+
+vi.mock('@/lib/prisma', () => ({
+  prisma: {
+    auction: { findMany: mockAuctionFindMany },
+    lot: { findMany: mockLotFindMany },
+    user: { findMany: mockUserFindMany },
+  },
+}));
+
+vi.mock('@/lib/actions/auth', () => ({
+  getTenantIdFromRequest: mockGetTenantIdFromRequest,
+}));
+
+describe('globalSearch action', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    mockGetTenantIdFromRequest.mockResolvedValue('7');
+    mockAuctionFindMany.mockResolvedValue([]);
+    mockLotFindMany.mockResolvedValue([]);
+    mockUserFindMany.mockResolvedValue([]);
+  });
+
+  it('returns empty and skips database calls for short query terms', async () => {
+    const { globalSearch } = await import('@/app/actions/global-search');
+    const result = await globalSearch('a');
+
+    expect(result).toEqual([]);
+    expect(mockGetTenantIdFromRequest).not.toHaveBeenCalled();
+    expect(mockAuctionFindMany).not.toHaveBeenCalled();
+    expect(mockLotFindMany).not.toHaveBeenCalled();
+    expect(mockUserFindMany).not.toHaveBeenCalled();
+  });
+
+  it('returns tenant-scoped auction, lot and user results with valid destination URLs', async () => {
+    mockAuctionFindMany.mockResolvedValue([
+      {
+        id: BigInt(10),
+        publicId: 'AUC-2026-0001',
+        title: 'Leilao Judicial Centro',
+        status: 'RASCUNHO',
+      },
+    ]);
+
+    mockLotFindMany.mockResolvedValue([
+      {
+        id: BigInt(20),
+        publicId: 'LOTE-0100',
+        title: 'Apartamento 2 quartos',
+        number: '100',
+        status: 'ABERTO_PARA_LANCES',
+      },
+    ]);
+
+    mockUserFindMany.mockResolvedValue([
+      {
+        id: BigInt(30),
+        fullName: 'Admin BidExpert',
+        email: 'admin@bidexpert.com.br',
+      },
+    ]);
+
+    const { globalSearch } = await import('@/app/actions/global-search');
+    const result = await globalSearch('AUC-2026');
+
+    expect(result).toHaveLength(3);
+
+    const auctionResult = result.find((item) => item.type === 'auction');
+    const lotResult = result.find((item) => item.type === 'lot');
+    const userResult = result.find((item) => item.type === 'user');
+
+    expect(auctionResult).toMatchObject({
+      id: '10',
+      title: 'Leilao Judicial Centro',
+      url: '/admin/auctions/AUC-2026-0001/edit',
+    });
+
+    expect(lotResult).toMatchObject({
+      id: '20',
+      title: 'Apartamento 2 quartos',
+      url: '/admin/lots/LOTE-0100/edit',
+    });
+
+    expect(userResult).toMatchObject({
+      id: '30',
+      title: 'Admin BidExpert',
+      url: '/admin-plus/users/30',
+    });
+
+    expect(mockGetTenantIdFromRequest).toHaveBeenCalledWith(false);
+
+    const auctionArgs = mockAuctionFindMany.mock.calls[0][0];
+    const lotArgs = mockLotFindMany.mock.calls[0][0];
+    const userArgs = mockUserFindMany.mock.calls[0][0];
+
+    expect(auctionArgs.where.tenantId).toBe(BigInt(7));
+    expect(lotArgs.where.tenantId).toBe(BigInt(7));
+    expect(userArgs.where.UsersOnTenants.some.tenantId).toBe(BigInt(7));
+  });
+});


### PR DESCRIPTION
## Resumo
- monta a Command Palette no layout admin legado
- corrige o atalho visual para Ctrl/Cmd conforme SO
- refatora a busca global com tenant scoping e URLs válidas de destino
- adiciona cobertura unitária, E2E e BDD do fluxo

## Validações locais
- npm run typecheck
- npx vitest run tests/unit/admin-global-search.spec.ts --config vitest.unit.config.ts
- npx playwright test tests/e2e/admin/admin-global-search.spec.ts --config playwright.autofix.config.ts --project chromium-autofix --project chromium-noauth
- HTML report local: http://127.0.0.1:9324