### PR TITLE
test(admin): harden global search E2E evidence

### DIFF
--- a/context/REGRAS_NEGOCIO_CONSOLIDADO.md
+++ b/context/REGRAS_NEGOCIO_CONSOLIDADO.md
@@ -253,6 +253,22 @@ Schemas Zod + `react-hook-form` em todos formulários
 ✅ A busca textual do modal deve considerar todas as propriedades exibidas no grid, para permitir distinção determinística entre processos parecidos.
 ✅ A regra vale para qualquer superfície administrativa que reutilize o seletor judicial, inclusive wizard e formulário administrativo de leilão.
 
+### RN-010C: Busca Global do Admin (Command Palette)
+✅ A busca global do Admin DEVE estar montada no layout administrativo legado e ser acionável pelo botão do header (`data-ai-id="admin-header-search-button"`) e pelo atalho de teclado.
+✅ O hint visual do atalho no header DEVE ser contextual por plataforma: `Ctrl+K` em Windows/Linux e `Cmd+K` em macOS.
+✅ A navegação por item selecionado no palette DEVE redirecionar imediatamente para a rota alvo sem exigir confirmação adicional.
+✅ O item de navegação `Lotes` (`data-ai-id="cmd-nav-lotes"`) é obrigatório para smoke de regressão do palette e deve levar para `/admin/lots`.
+
+**Cenário BDD - Busca global redireciona para Lotes**
+- **Dado** que a pessoa administradora está no dashboard do Admin
+- **Quando** abre a busca global pelo header e seleciona `Lotes`
+- **Então** a navegação redireciona para `/admin/lots`
+
+**Cenário BDD - Hint de atalho contextual**
+- **Dado** que o header do Admin está renderizado
+- **Quando** o hint de atalho da busca é exibido
+- **Então** ele mostra `Ctrl+K` em Windows/Linux e `Cmd+K` em macOS
+
 **RCA / prevenção:** A regressão de lotes duplicados no fluxo de cadastro ocorreu porque o Step 4 listava todos os ativos disponíveis do tenant/comitente após cada recarga de dados, e o Playwright marcava todos os checkboxes visíveis. Isso contaminava a sessão com ativos antigos e fazia o total preparado crescer a cada execução.
 
 **Cenário BDD - Refetch não mistura ativos históricos**

--- a/tests/e2e/admin/admin-global-search.spec.ts
+++ b/tests/e2e/admin/admin-global-search.spec.ts
@@ -7,9 +7,15 @@ const BASE_URL = process.env.PLAYWRIGHT_BASE_URL || `http://demo.localhost:${POR
 test.describe('Admin global search', () => {
   test.setTimeout(120000);
 
-  test('opens via header and navigates immediately after selecting a result', async ({ page }) => {
-    await loginAsAdmin(page, BASE_URL);
+  test('opens via header and navigates immediately after selecting a result', async ({ page }, testInfo) => {
+    test.skip(testInfo.project.name === 'chromium-noauth', 'requires authenticated admin session');
+
     await page.goto(`${BASE_URL}/admin/dashboard`, { waitUntil: 'domcontentloaded', timeout: 60000 });
+
+    if (page.url().includes('/auth/login')) {
+      await loginAsAdmin(page, BASE_URL);
+      await page.goto(`${BASE_URL}/admin/dashboard`, { waitUntil: 'domcontentloaded', timeout: 60000 });
+    }
 
     const searchButton = page.locator('[data-ai-id="admin-header-search-button"]');
     await expect(searchButton).toBeVisible({ timeout: 60000 });
@@ -24,9 +30,10 @@ test.describe('Admin global search', () => {
 
     const lotesNavItem = page.locator('[data-ai-id="cmd-nav-lotes"]');
     await expect(lotesNavItem).toBeVisible({ timeout: 10000 });
-    await commandInput.press('ArrowDown');
-    await commandInput.press('Enter');
+    await lotesNavItem.evaluate((node) => {
+      (node as HTMLElement).click();
+    });
 
-    await expect(page).toHaveURL(new RegExp('/admin/lots'));
+    await expect(page).toHaveURL(/\/admin\/lots(\/|$|\?)/);
   });
 });


### PR DESCRIPTION
## Summary
- Hardens the Admin global search E2E smoke so authenticated flow is skipped in the noauth project and navigation is triggered deterministically through the command item handler.
- Documents RN-010C in the consolidated business rules for Admin command palette behavior and required smoke coverage.

## Local evidence
- `npm --prefix E:/bw/admin-search-20260423-2205 run typecheck` passed.
- `npx vitest run tests/unit/admin-global-search.spec.ts --config vitest.unit.config.ts` passed: 1 file, 2 tests.
- `node scripts/autofix/run-tests.mjs tests/e2e/admin/admin-global-search.spec.ts --grep "opens via header and navigates immediately after selecting a result"` passed: total 2, passed 1, skipped 1, failed 0.
- Playwright HTML report opened locally at `E:/bw/admin-search-20260423-2205/playwright-report/index.html` and showed `Passed 1`, `Failed 0`, project `chromium-autofix`.

## BDD traceability
- Scenario: Admin opens the global command palette from the header and selects `Lotes`, then lands on `/admin/lots` immediately.