### PR TITLE
fix(lots): constrain linked asset thumbnails

### DIFF
--- a/src/app/admin/lots/lot-form.tsx
+++ b/src/app/admin/lots/lot-form.tsx
@@ -472,8 +472,8 @@ const LotForm = forwardRef<any, LotFormProps>(({
     { value: 'BAIXO', label: 'Baixo' },
   ];
   const renderAssetGridItem = (asset: Asset) => (
-    <Card key={asset.id} className="container-bem-grid-item">
-        <CardHeader className="p-3"><div className="wrapper-bem-grid-image"><Image src={asset.imageUrl || 'https://placehold.co/400x300.png'} alt={asset.title} fill sizes="(max-width: 640px) 40vw, 150px" className="object-cover" data-ai-hint={asset.dataAiHint || asset.categoryName?.toLowerCase() || 'bem item'} /></div><CardTitle className="title-bem-grid-item">{asset.title}</CardTitle><CardDescription className="description-bem-grid-item">ID: {asset.publicId || asset.id}</CardDescription></CardHeader>
+    <Card key={asset.id} className="container-bem-grid-item flex h-full flex-col">
+        <CardHeader className="p-3"><div className="wrapper-bem-grid-image relative aspect-[4/3] w-full overflow-hidden rounded-md border bg-muted"><Image src={asset.imageUrl || 'https://placehold.co/400x300.png'} alt={asset.title} fill sizes="(max-width: 640px) 40vw, 150px" className="object-cover" data-ai-hint={asset.dataAiHint || asset.categoryName?.toLowerCase() || 'bem item'} /></div><CardTitle className="title-bem-grid-item mt-3 line-clamp-2 text-sm">{asset.title}</CardTitle><CardDescription className="description-bem-grid-item">ID: {asset.publicId || asset.id}</CardDescription></CardHeader>
         <CardContent className="p-3 flex-grow space-y-1 text-xs"><p className="font-medium">Avaliação: {asset.evaluationValue?.toLocaleString('pt-BR', { style: 'currency', currency: 'BRL' }) || 'N/A'}</p></CardContent>
         <CardFooter className="p-2 border-t flex justify-end items-center gap-1"><Button variant="ghost" size="icon" onClick={() => handleViewAssetDetails(asset)} className="h-7 w-7 text-sky-600"><Eye className="h-3.5 w-3.5" /></Button><Button variant="ghost" size="icon" onClick={() => handleUnlinkAsset(asset.id)} disabled={isAssetLinkingLocked} className="h-7 w-7 text-destructive"><Trash2 className="h-3.5 w-3.5" /></Button></CardFooter>
     </Card>
@@ -481,11 +481,11 @@ const LotForm = forwardRef<any, LotFormProps>(({
 
   const renderAssetListItem = (asset: Asset) => (
     <Card key={asset.id} className="container-bem-list-item">
-      <CardContent className="content-bem-list-item">
-        <div className="wrapper-bem-list-image"><Image src={asset.imageUrl || 'https://placehold.co/120x90.png'} alt={asset.title} fill sizes="80px" className="object-cover" data-ai-hint={asset.dataAiHint || asset.categoryName?.toLowerCase() || 'bem item'} /></div>
-        <div className="flex-grow"><h4 className="title-bem-list-item">{asset.title}</h4><p className="description-bem-list-item">ID: {asset.publicId || asset.id}</p></div>
-        <div className="container-bem-list-price"><p className="price-bem-list-item">{asset.evaluationValue?.toLocaleString('pt-BR', { style: 'currency', currency: 'BRL' }) || 'N/A'}</p><p className="label-bem-list-price">Avaliação</p></div>
-         <div className="container-bem-list-actions"><Button variant="ghost" size="icon" onClick={() => handleViewAssetDetails(asset)} className="h-8 w-8 text-sky-600"><Eye className="h-4 w-4" /></Button><Button variant="ghost" size="icon" onClick={() => handleUnlinkAsset(asset.id)} disabled={isAssetLinkingLocked} className="h-8 w-8 text-destructive"><Trash2 className="h-4 w-4" /></Button></div>
+      <CardContent className="content-bem-list-item flex flex-wrap items-center gap-4 p-4 sm:flex-nowrap">
+        <div className="wrapper-bem-list-image relative h-20 w-20 shrink-0 overflow-hidden rounded-md border bg-muted"><Image src={asset.imageUrl || 'https://placehold.co/120x90.png'} alt={asset.title} fill sizes="80px" className="object-cover" data-ai-hint={asset.dataAiHint || asset.categoryName?.toLowerCase() || 'bem item'} /></div>
+        <div className="min-w-0 flex-grow"><h4 className="title-bem-list-item truncate text-sm font-semibold">{asset.title}</h4><p className="description-bem-list-item text-xs text-muted-foreground">ID: {asset.publicId || asset.id}</p></div>
+        <div className="container-bem-list-price shrink-0 text-left sm:text-right"><p className="price-bem-list-item text-sm font-medium">{asset.evaluationValue?.toLocaleString('pt-BR', { style: 'currency', currency: 'BRL' }) || 'N/A'}</p><p className="label-bem-list-price text-xs text-muted-foreground">Avaliação</p></div>
+         <div className="container-bem-list-actions ml-auto flex shrink-0 items-center gap-1"><Button variant="ghost" size="icon" onClick={() => handleViewAssetDetails(asset)} className="h-8 w-8 text-sky-600"><Eye className="h-4 w-4" /></Button><Button variant="ghost" size="icon" onClick={() => handleUnlinkAsset(asset.id)} disabled={isAssetLinkingLocked} className="h-8 w-8 text-destructive"><Trash2 className="h-4 w-4" /></Button></div>
       </CardContent>
     </Card>
   );

--- a/tests/e2e/admin/lot-155-media-vercel.spec.ts
+++ b/tests/e2e/admin/lot-155-media-vercel.spec.ts
@@ -1,0 +1,105 @@
+/**
+ * @fileoverview BDD/TDD regression check for linked-asset thumbnail layout on lot edit pages.
+ * Given a lot edit page with linked assets
+ * When an admin opens the lot form
+ * Then the thumbnail wrapper must keep the image constrained to the expected 80px slot.
+ */
+import { expect, test } from '@playwright/test';
+import { ensureSeedExecuted, loginAsAdmin } from '../helpers/auth-helper';
+
+const BASE_URL = process.env.PLAYWRIGHT_BASE_URL || process.env.BASE_URL || 'https://demo.bidexpert.com.br';
+const LOT_ID = process.env.PLAYWRIGHT_LOT_ID || '155';
+const EXPECTED_THUMBNAIL_SIZE = Number(process.env.PLAYWRIGHT_EXPECTED_THUMBNAIL_SIZE || '80');
+const SHOULD_EXPECT_REAL_MEDIA =
+  process.env.PLAYWRIGHT_EXPECT_REAL_MEDIA === '1' || /demo\.bidexpert\.com\.br/i.test(BASE_URL);
+const VERCEL_SHARE_TOKEN = process.env.VERCEL_SHARE_TOKEN || '';
+
+test.describe('Lot linked-asset thumbnail layout regression', () => {
+  test.beforeAll(async () => {
+    await ensureSeedExecuted(BASE_URL);
+  });
+
+  test('keeps the linked-asset thumbnail inside a fixed wrapper', async ({ page }) => {
+    if (VERCEL_SHARE_TOKEN) {
+      await page.goto(`${BASE_URL}/?_vercel_share=${VERCEL_SHARE_TOKEN}`, {
+        waitUntil: 'domcontentloaded',
+        timeout: 60_000,
+      });
+    }
+
+    await page.goto(`${BASE_URL}/admin/lots/${LOT_ID}/edit`, {
+      waitUntil: 'domcontentloaded',
+      timeout: 60_000,
+    });
+
+    if (/\/auth\/login/i.test(page.url())) {
+      await loginAsAdmin(page, BASE_URL);
+      await page.goto(`${BASE_URL}/admin/lots/${LOT_ID}/edit`, {
+        waitUntil: 'domcontentloaded',
+        timeout: 60_000,
+      });
+    }
+
+    await page.waitForFunction(
+      () => !document.body.innerText.includes('Carregando painel administrativo'),
+      { timeout: 60_000 },
+    ).catch(() => undefined);
+
+    const wrapper = page.locator('.wrapper-bem-list-image').first();
+    await expect(wrapper).toBeVisible({ timeout: 60_000 });
+
+    const metrics = await page.evaluate(() => {
+      const wrapperElement = document.querySelector<HTMLElement>('.wrapper-bem-list-image');
+      const imageElement = wrapperElement?.querySelector<HTMLImageElement>('img');
+
+      if (!wrapperElement || !imageElement) {
+        return null;
+      }
+
+      const wrapperRect = wrapperElement.getBoundingClientRect();
+      const imageRect = imageElement.getBoundingClientRect();
+      const wrapperStyle = getComputedStyle(wrapperElement);
+      const imageStyle = getComputedStyle(imageElement);
+
+      return {
+        wrapper: {
+          width: Math.round(wrapperRect.width),
+          height: Math.round(wrapperRect.height),
+          position: wrapperStyle.position,
+          overflow: wrapperStyle.overflow,
+          display: wrapperStyle.display,
+        },
+        image: {
+          width: Math.round(imageRect.width),
+          height: Math.round(imageRect.height),
+          sizes: imageElement.getAttribute('sizes'),
+          objectFit: imageStyle.objectFit,
+          src: imageElement.getAttribute('src') || '',
+          alt: imageElement.getAttribute('alt') || '',
+        },
+      };
+    });
+
+    expect(metrics).not.toBeNull();
+    expect(metrics?.wrapper.position).toBe('relative');
+    expect(metrics?.wrapper.overflow).toBe('hidden');
+    expect(metrics?.wrapper.display).toBe('block');
+    expect(metrics?.wrapper.width).toBeGreaterThanOrEqual(EXPECTED_THUMBNAIL_SIZE - 20);
+    expect(metrics?.wrapper.width).toBeLessThanOrEqual(EXPECTED_THUMBNAIL_SIZE + 40);
+    expect(metrics?.wrapper.height).toBeGreaterThanOrEqual(EXPECTED_THUMBNAIL_SIZE - 20);
+    expect(metrics?.wrapper.height).toBeLessThanOrEqual(EXPECTED_THUMBNAIL_SIZE + 40);
+
+    expect(metrics?.image.sizes).toBe(`${EXPECTED_THUMBNAIL_SIZE}px`);
+    expect(metrics?.image.objectFit).toBe('cover');
+    expect(metrics?.image.width).toBeGreaterThanOrEqual(EXPECTED_THUMBNAIL_SIZE - 5);
+    expect(metrics?.image.width).toBeLessThanOrEqual((metrics?.wrapper.width ?? EXPECTED_THUMBNAIL_SIZE) + 5);
+    expect(metrics?.image.height).toBeGreaterThanOrEqual(EXPECTED_THUMBNAIL_SIZE - 5);
+    expect(metrics?.image.height).toBeLessThanOrEqual((metrics?.wrapper.height ?? EXPECTED_THUMBNAIL_SIZE) + 5);
+
+    if (SHOULD_EXPECT_REAL_MEDIA) {
+      expect(metrics?.image.src).toContain('public.blob.vercel-storage.com');
+      expect(metrics?.image.src).not.toContain('picsum.photos');
+      expect(metrics?.image.src).not.toContain('placehold.co');
+    }
+  });
+});

--- a/tests/itsm/features/lot-linked-asset-thumbnail-layout.feature
+++ b/tests/itsm/features/lot-linked-asset-thumbnail-layout.feature
@@ -1,0 +1,11 @@
+Feature: Linked asset thumbnail layout on lot edit pages
+  As an admin editing a lot with linked assets
+  I want each linked-asset thumbnail to stay inside a fixed 80px wrapper
+  So that media previews never expand to the full page width
+
+  Scenario: Linked asset thumbnail stays clipped and sized on the lot edit page
+    Given the lot edit route has at least one linked asset thumbnail
+    When the admin opens the lot edit form
+    Then the first thumbnail wrapper is relative and hides overflow
+    And the wrapper stays near 80 by 80 pixels
+    And the image uses object-fit cover with sizes equal to 80px


### PR DESCRIPTION
## Summary
- constrain the linked-asset thumbnail wrapper in the lot edit form so 
ext/image fill stays inside a fixed slot
- add a focused Playwright regression for the linked-asset thumbnail geometry contract
- document the expected wrapper behavior in BDD

## Validation
- 
px playwright test tests/e2e/admin/lot-155-media-vercel.spec.ts --config=playwright.config.local.ts
- 
pm run typecheck
- 
pm run build with explicit local DATABASE_URL and auth secrets
