### PR TITLE
feat: pregão multi-perfil filmado

### DIFF
--- a/.github/workflows/p0-ci.yml
+++ b/.github/workflows/p0-ci.yml
@@ -162,6 +162,7 @@ jobs:
           PLAYWRIGHT_SKIP_WEBSERVER: '1'
 
       - name: Run E2E Tests
+        timeout-minutes: 20
         run: npm run test:e2e -- --reporter=html --reporter=json
         env:
           DATABASE_URL: mysql://root:root@localhost:3306/bidexpert_test

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,12 @@ O formato é baseado em [Keep a Changelog](https://keepachangelog.com/pt-BR/1.0.
 e este projeto segue o [Semantic Versioning](https://semver.org/lang/pt-BR/).
 
 
+## [1.0.0-demo.47](https://github.com/augustodevcode/bidexpert_ai_firebase_studio/compare/v1.0.0-demo.46...v1.0.0-demo.47) (2026-04-28)
+
+### Funcionalidades
+
+* add lotting operating modes autosave ([e67ceb7](https://github.com/augustodevcode/bidexpert_ai_firebase_studio/commit/e67ceb7f2d2a3ba9b763a35dc5e25e1dec7d99ef))
+
 ## [1.0.0-demo.46](https://github.com/augustodevcode/bidexpert_ai_firebase_studio/compare/v1.0.0-demo.45...v1.0.0-demo.46) (2026-04-28)
 
 ### Funcionalidades

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,12 @@ O formato é baseado em [Keep a Changelog](https://keepachangelog.com/pt-BR/1.0.
 e este projeto segue o [Semantic Versioning](https://semver.org/lang/pt-BR/).
 
 
+## [1.0.0-demo.46](https://github.com/augustodevcode/bidexpert_ai_firebase_studio/compare/v1.0.0-demo.45...v1.0.0-demo.46) (2026-04-28)
+
+### Funcionalidades
+
+* **admin:** align judicial selector and audit summary ([9281834](https://github.com/augustodevcode/bidexpert_ai_firebase_studio/commit/92818344aa7a761ed550370885d460e5acbd4abf))
+
 ## [1.0.0-demo.45](https://github.com/augustodevcode/bidexpert_ai_firebase_studio/compare/v1.0.0-demo.44...v1.0.0-demo.45) (2026-04-27)
 
 ### Correções

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,12 @@ O formato é baseado em [Keep a Changelog](https://keepachangelog.com/pt-BR/1.0.
 e este projeto segue o [Semantic Versioning](https://semver.org/lang/pt-BR/).
 
 
+## [1.0.0-demo.45](https://github.com/augustodevcode/bidexpert_ai_firebase_studio/compare/v1.0.0-demo.44...v1.0.0-demo.45) (2026-04-27)
+
+### Correções
+
+* **lots:** constrain linked asset thumbnails ([#744](https://github.com/augustodevcode/bidexpert_ai_firebase_studio/issues/744)) ([b756618](https://github.com/augustodevcode/bidexpert_ai_firebase_studio/commit/b756618e03f0fbe3eec990f510eec3c8fcfb4639))
+
 ## [1.0.0-demo.44](https://github.com/augustodevcode/bidexpert_ai_firebase_studio/compare/v1.0.0-demo.43...v1.0.0-demo.44) (2026-04-27)
 
 ### Correções

--- a/context/REGRAS_NEGOCIO_CONSOLIDADO.md
+++ b/context/REGRAS_NEGOCIO_CONSOLIDADO.md
@@ -364,6 +364,8 @@ Schemas Zod + `react-hook-form` em todos formulários
 ✅ A tela de edição do leilão e superfícies correlatas DEVEM buscar lotes somente por filtro explícito de `auctionId`, respeitando a assinatura real de `getLots`, para impedir vazamento de lotes de outros leilões.
 ✅ O histórico de alterações do leilão só é considerado íntegro quando a mutation persistir registros de auditoria e o endpoint de leitura conseguir normalizar eventos armazenados em `changes` e também em `oldValues/newValues`.
 ✅ A numeração visível dos lotes no wizard e no controle de preparação DEVE sair de uma regra centralizada, e não de contagem local de array sujeita a reinício após re-fetches ou agrupamentos.
+✅ O loteamento administrativo DEVE expor modos operacionais explícitos (`Rápido`, `Planilha Operacional`, `IA Assistida`) para que o operador entenda em qual estratégia de triagem está atuando antes de criar lotes.
+✅ As preferências operacionais do loteamento (modo, incluir agrupados, somente sinalizados e valor mínimo) DEVEM ser auto-salvas localmente com feedback visual imediato, sem persistir seleções transitórias de processo/leilão como se fossem preferência estável.
 
 **RCA / prevenção:** Os bugs de imagem principal, vazamento de lotes e histórico vazio surgiram porque os contratos reais dos componentes/serviços compartilhados não estavam sendo respeitados: a biblioteca de mídia retornava outros campos, `getLots` exigia filtro estruturado e a trilha de auditoria não estava sendo lida e persistida de forma compatível entre caminhos diferentes.
 
@@ -378,6 +380,13 @@ Schemas Zod + `react-hook-form` em todos formulários
 - **Quando** o usuário abre a tela de edição
 - **Então** apenas os lotes do `auctionId` atual são exibidos
 - **E** a aba de histórico mostra mudanças persistidas da entidade em formato legível
+
+**Cenário BDD - Loteamento salva modo operacional automaticamente**
+- **Dado** que o operador está na tela administrativa de loteamento
+- **Quando** ele alterna entre `Rápido`, `Planilha Operacional` e `IA Assistida`
+- **Então** a tela deixa claro qual modo está ativo
+- **E** as preferências operacionais são salvas automaticamente com indicador visual
+- **E** processo judicial e leilão de destino não são restaurados como preferência persistente em uma nova sessão
 
 ### RN-010G: Auditoria mínima no topo do formulário de leilão
 ✅ Superfícies administrativas de edição/cadastro de leilão DEVEM expor um resumo mínimo de auditoria quando existirem dados auditáveis da entidade atual.

--- a/context/REGRAS_NEGOCIO_CONSOLIDADO.md
+++ b/context/REGRAS_NEGOCIO_CONSOLIDADO.md
@@ -160,6 +160,21 @@ Controller (Server Action) → Service → Repository → ZOD → Prisma ORM →
 - **Quando** a interface renderiza card/lista/detalhe/modal de leilão/lote
 - **Então** o CTA "Ir para pregão online" não é exibido
 
+### RN-017A: Pregão Multi-Perfil Filmado
+✅ Toda evidência filmada de pregão competitivo deve usar atores separados por perfil em contextos Playwright independentes: agente do leilão, administrador, leiloeiro, 10 compradores, analista e câmera do monitor.
+✅ O administrador habilita compradores, mas nunca pode ser usado como comprador ou origem de lance.
+✅ Os 10 compradores devem ter perfil de arrematante, associação ao tenant e habilitação específica no leilão antes do primeiro lance.
+✅ O leiloeiro controla abertura do leilão, início do lote em pregão, confirmação do vencedor, fechamento do lote e encerramento do leilão pela máquina de estado oficial.
+✅ Lances da jornada automatizada devem passar pelo `BidEngineV2`; gravação direta de `Bid` no banco só é permitida para fixtures legadas explicitamente marcadas como não filmadas.
+✅ O monitor de auditório (`/auctions/{auctionId}/monitor`) é a câmera principal e deve registrar valor atual, quantidade de lances, líder e banner de vencedor quando aplicável.
+✅ O vencedor é sempre o maior lance ativo confirmado pela máquina de estado; relatórios, laudos, cobrança e parcelas do analista só podem referenciar esse vencedor.
+✅ Toda mudança nesse fluxo exige BDD rastreável, teste unitário das regras puras/fixture e execução Playwright com vídeo/print/relatório.
+
+**Cenário BDD - Jornada filmada multi-perfil**
+- **Dado** um pregão criado por agente de leilão e 10 compradores habilitados pelo administrador
+- **Quando** o leiloeiro abre o pregão e os compradores disputam lances pelo motor oficial
+- **Então** o monitor filmado mostra a evolução da disputa, o maior lance é confirmado como vencedor e o analista emite artefatos somente para esse vencedor
+
 ### RN-005: Herança de Mídia
 ✅ Lote pode herdar galeria de `Asset` vinculado  
 ✅ Leilão pode herdar imagem de Lote vinculado  

--- a/context/REGRAS_NEGOCIO_CONSOLIDADO.md
+++ b/context/REGRAS_NEGOCIO_CONSOLIDADO.md
@@ -252,6 +252,8 @@ Schemas Zod + `react-hook-form` em todos formulários
 ✅ As colunas `Bens` e `Lotes` são obrigatórias e não podem ser removidas do grid judicial.
 ✅ A busca textual do modal deve considerar todas as propriedades exibidas no grid, para permitir distinção determinística entre processos parecidos.
 ✅ A regra vale para qualquer superfície administrativa que reutilize o seletor judicial, inclusive wizard e formulário administrativo de leilão.
+✅ As superfícies `auction-form`, `auction-form-v2`, `asset-form-v2` e `lotting/page` DEVEM consumir o helper compartilhado `buildJudicialProcessSelectorOptions` com `judicialProcessSelectorColumns`; é proibido voltar a montar opções simplificadas locais com apenas `processNumber`.
+✅ Os headers do grid judicial DEVEM manter `data-ai-id` estáveis (`judicial-process-selector-header-*`) para garantir regressão automatizada do modal compartilhado.
 
 ### RN-010C: Busca Global do Admin (Command Palette)
 ✅ A busca global do Admin DEVE estar montada no layout administrativo legado e ser acionável pelo botão do header (`data-ai-id="admin-header-search-button"`) e pelo atalho de teclado.
@@ -282,6 +284,12 @@ Schemas Zod + `react-hook-form` em todos formulários
 - **Quando** o fluxo do wizard precisa vincular o processo de referência
 - **Então** o processo é selecionado pelo número exato
 - **E** nunca pela primeira linha disponível da listagem
+
+**Cenário BDD - Superfícies compartilham o mesmo grid judicial**
+- **Dado** que o admin abre o seletor de processo judicial no leilão, no ativo ou no loteamento
+- **Quando** o modal de processo é exibido
+- **Então** as mesmas colunas ampliadas permanecem visíveis em todas as telas
+- **E** a busca textual continua cobrindo comitente, vara, comarca, tribunal, partes, matrícula, registro e CNJ
 
 ### RN-010B: Publicação de Leilão deve ser idempotente para slug
 ✅ A criação de leilão DEVE tolerar colisão de `slug` em reexecuções de testes e cadastros repetidos, gerando um sufixo incremental quando houver conflito de unicidade.
@@ -370,6 +378,18 @@ Schemas Zod + `react-hook-form` em todos formulários
 - **Quando** o usuário abre a tela de edição
 - **Então** apenas os lotes do `auctionId` atual são exibidos
 - **E** a aba de histórico mostra mudanças persistidas da entidade em formato legível
+
+### RN-010G: Auditoria mínima no topo do formulário de leilão
+✅ Superfícies administrativas de edição/cadastro de leilão DEVEM expor um resumo mínimo de auditoria quando existirem dados auditáveis da entidade atual.
+✅ O resumo mínimo DEVE mostrar, no mínimo: `Criado por`, `Atualizado em`, `Enviado para validação`, `Validado por` e `Validado em`, com fallback explícito quando alguma informação ainda não existir.
+✅ Quando o leilão já existir, o bloco de auditoria DEVE oferecer atalho direto para `/admin/auctions/{auctionId}/history`.
+✅ O resumo é complementar ao histórico completo: ele não substitui a aba/página de histórico nem pode omitir o link quando houver entidade persistida.
+
+**Cenário BDD - Resumo mínimo de auditoria aparece na edição**
+- **Dado** que o admin abriu o formulário de um leilão já persistido
+- **Quando** a tela de edição é renderizada
+- **Então** o topo do formulário mostra os metadados mínimos de auditoria disponíveis
+- **E** existe um atalho para abrir o histórico completo do leilão
 
 ### RN-011: Campo Propriedades em Formulários
 Campo "Propriedades" é um **campo de texto simples**  

--- a/playwright.config.local.ts
+++ b/playwright.config.local.ts
@@ -3,7 +3,7 @@ import { defineConfig, devices } from '@playwright/test';
 const shouldStartWebServer = process.env.PLAYWRIGHT_SKIP_WEBSERVER !== '1';
 const isCI = process.env.CI === '1' || process.env.CI === 'true';
 
-const baseURL = process.env.BASE_URL || 'http://localhost:9002';
+const baseURL = (process.env.BASE_URL || 'http://localhost:9002').trim();
 
 export default defineConfig({
 	testDir: './tests/e2e',

--- a/playwright.pregao-video.config.ts
+++ b/playwright.pregao-video.config.ts
@@ -20,8 +20,8 @@ export default defineConfig({
   testDir: './tests/e2e',
   testMatch: '**/pregao-disputas-video.spec.ts',
 
-  // Timeout generoso: 10 minutos para acomodar o pregão de 5 min + setup
-  timeout: 10 * 60 * 1000,
+  // Timeout generoso: atores separados, lifecycle, 10 compradores e evidência visual
+  timeout: 20 * 60 * 1000,
   expect: { timeout: 30_000 },
 
   // Serial: todos os passos rodam em sequência para vídeo coerente
@@ -38,15 +38,15 @@ export default defineConfig({
   use: {
     baseURL: BASE_URL,
 
-    // ── Gravação de vídeo SEMPRE ativa ──────────────────────────────────────
-    video: 'on',
+    // A gravação é habilitada manualmente apenas no cameraPage principal.
+    video: 'off',
     videoSize: { width: 1280, height: 720 },
 
-    // Screenshots em cada passo
-    screenshot: 'on',
+    // A spec captura screenshots nomeados nos marcos BDD.
+    screenshot: 'only-on-failure',
 
-    // Trace completo para debugging pós-test
-    trace: 'on',
+    // Evita artefatos massivos em execuções com muitos contextos.
+    trace: 'retain-on-failure',
 
     // Timeouts
     actionTimeout: 30_000,

--- a/src/app/admin/assets/asset-form-v2.tsx
+++ b/src/app/admin/assets/asset-form-v2.tsx
@@ -21,6 +21,10 @@ import { getSubcategoriesByParentIdAction } from '../subcategories/actions';
 import ChooseMediaDialog from '@/components/admin/media/choose-media-dialog';
 import Image from 'next/image';
 import EntitySelector from '@/components/ui/entity-selector';
+import {
+    buildJudicialProcessSelectorOptions,
+    judicialProcessSelectorColumns,
+} from '@/components/admin/judicial-processes/judicial-process-selector-config';
 import AddressGroup from '@/components/address-group';
 import AssetSpecificFields from './asset-specific-fields';
 import { CrudFormLayout } from '@/components/crud/crud-form-layout';
@@ -131,6 +135,10 @@ export function AssetFormV2({
     const watchedMainImageUrl = useWatch({ control: form.control, name: 'imageUrl' });
     const watchedGalleryImageUrls = useWatch({ control: form.control, name: 'galleryImageUrls' }) || [];
   const selectedCategory = safeCategories.find(c => c.id.toString() === selectedCategoryId);
+    const judicialProcessOptions = React.useMemo(
+        () => buildJudicialProcessSelectorOptions(safeProcesses),
+        [safeProcesses]
+    );
   console.log('AssetFormV2: selectedCategoryId', selectedCategoryId);
   console.log('AssetFormV2: selectedCategory', selectedCategory);
 
@@ -421,13 +429,15 @@ export function AssetFormV2({
                                     <FormItem>
                                         <FormLabel>Processo Judicial (Opcional)</FormLabel>
                                         <EntitySelector
-                                            entityName="process"
-                                            options={safeProcesses.map(p => ({ value: p.id.toString(), label: p.processNumber }))}
+                                            entityName="processo judicial"
+                                            options={judicialProcessOptions}
                                             value={field.value || ''}
                                             onChange={field.onChange}
                                             placeholder="Vincular a processo..."
-                                            searchPlaceholder="Buscar processo..."
+                                            searchPlaceholder="Buscar processo, comitente, vara, comarca, tribunal, partes, matrícula, registro ou CNJ..."
                                             emptyStateMessage="Nenhum processo encontrado."
+                                            displayColumns={judicialProcessSelectorColumns}
+                                            dialogDescription="Selecione o processo judicial correto. O grid mostra número, comitente, vara, comarca, tribunal, partes e os totais de bens/lotes para evitar seleção ambígua."
                                         />
                                         <FormMessage />
                                     </FormItem>

--- a/src/app/admin/auctions-v2/components/auction-form-v2.tsx
+++ b/src/app/admin/auctions-v2/components/auction-form-v2.tsx
@@ -20,6 +20,11 @@ import { Separator } from '@/components/ui/separator';
 import { Textarea } from '@/components/ui/textarea';
 import { Loader2, PlusCircle, Search, Trash2, Image as ImageIcon, XCircle } from 'lucide-react';
 import EntitySelector from '@/components/ui/entity-selector';
+import { AuctionAuditSummary } from '@/components/admin/auctions/auction-audit-summary';
+import {
+  buildJudicialProcessSelectorOptions,
+  judicialProcessSelectorColumns,
+} from '@/components/admin/judicial-processes/judicial-process-selector-config';
 import { consultaCepAction } from '@/lib/actions/cep';
 import { useToast } from '@/hooks/use-toast';
 import ChooseMediaDialog from '@/components/admin/media/choose-media-dialog';
@@ -313,6 +318,10 @@ export default function AuctionFormV2({
     () => getCitiesForState(allCities, selectedStateId),
     [selectedStateId, allCities]
   );
+  const judicialProcessOptions = useMemo(
+    () => buildJudicialProcessSelectorOptions(judicialProcesses),
+    [judicialProcesses]
+  );
   const [isCepPending, startCepTransition] = useTransition();
   const { toast } = useToast();
   const [isMediaDialogOpen, setIsMediaDialogOpen] = useState(false);
@@ -485,6 +494,15 @@ export default function AuctionFormV2({
   return (
     <Form {...form}>
       <form onSubmit={handleFormSubmit} className="space-y-6">
+        <AuctionAuditSummary
+          createdByUserId={initialData?.createdByUserId ?? null}
+          updatedAt={initialData?.updatedAt ?? null}
+          submittedAt={initialData?.submittedAt ?? null}
+          validatedAt={initialData?.validatedAt ?? null}
+          validatedBy={initialData?.validatedBy ?? null}
+          historyHref={initialData?.id ? `/admin/auctions/${initialData.id}/history` : undefined}
+        />
+
         <Card>
           <CardHeader>
             <CardTitle>Informações Básicas</CardTitle>
@@ -672,15 +690,15 @@ export default function AuctionFormV2({
                   <FormLabel>Processo Judicial</FormLabel>
                   <FormControl>
                     <EntitySelector
+                      entityName="processo judicial"
                       value={field.value}
                       onChange={field.onChange}
-                      options={judicialProcesses.map((item) => ({
-                        value: item.id,
-                        label: item.processNumber,
-                      }))}
+                      options={judicialProcessOptions}
                       placeholder="Associe um processo"
-                      searchPlaceholder="Buscar processo..."
+                      searchPlaceholder="Buscar processo, comitente, vara, comarca, tribunal, partes, matrícula, registro ou CNJ..."
                       emptyStateMessage="Nenhum processo encontrado"
+                      displayColumns={judicialProcessSelectorColumns}
+                      dialogDescription="Selecione o processo judicial correto. O grid mostra número, comitente, vara, comarca, tribunal, partes, dados cadastrais do processo e os totais de bens/lotes para evitar seleção ambígua."
                       isFetching={false}
                     />
                   </FormControl>

--- a/src/app/admin/auctions/auction-form.tsx
+++ b/src/app/admin/auctions/auction-form.tsx
@@ -43,6 +43,7 @@ import AddressGroup from '@/components/address-group';
 import { getLotCategories } from '../categories/actions';
 import { ChangeHistoryTab } from '@/components/audit/change-history-tab';
 import { ParticipantCard, type ParticipantCardData } from '@/components/admin/participant-card';
+import { AuctionAuditSummary } from '@/components/admin/auctions/auction-audit-summary';
 import { AuctionDocumentsField } from '@/components/admin/auctions/auction-documents-field';
 import {
   buildJudicialProcessSelectorOptions,
@@ -798,6 +799,15 @@ const AuctionForm = forwardRef<any, AuctionFormProps>(({
         <FormProvider {...form}>
           <Form {...form}>
             <form onSubmit={form.handleSubmit(onSubmit)} className="space-y-8">
+
+              <AuctionAuditSummary
+                createdByUserId={initialData?.createdByUserId ?? null}
+                updatedAt={initialData?.updatedAt ?? null}
+                submittedAt={initialData?.submittedAt ?? null}
+                validatedAt={initialData?.validatedAt ?? null}
+                validatedBy={initialData?.validatedBy ?? null}
+                historyHref={initialData?.id ? `/admin/auctions/${initialData.id}/history` : undefined}
+              />
 
               <Card>
                 <CardHeader>

--- a/src/app/admin/lotting/page.tsx
+++ b/src/app/admin/lotting/page.tsx
@@ -20,7 +20,7 @@ import { getAuctions } from '../auctions/actions';
 import { createLot } from '../lots/actions';
 import { getLottingSnapshotAction } from './actions';
 import type { JudicialProcess, Asset, Auction } from '@/types';
-import type { LottingFilterState, LottingSnapshot } from '@/types/lotting';
+import type { LottingFilterState, LottingMode, LottingSnapshot } from '@/types/lotting';
 import CreateLotFromAssetsModal from '@/components/admin/lotting/create-lot-modal';
 import AssetDetailsModal from '@/components/admin/assets/asset-details-modal';
 import { createColumns } from '@/components/admin/lotting/columns';
@@ -29,6 +29,11 @@ import {
   buildJudicialProcessSelectorOptions,
   judicialProcessSelectorColumns,
 } from '@/components/admin/judicial-processes/judicial-process-selector-config';
+import {
+  getDefaultLottingFilters,
+  loadLottingPreferences,
+  saveLottingPreferences,
+} from '@/lib/lotting/preferences';
 
 const severityStyles = {
   high: 'bg-red-100 text-red-800',
@@ -36,12 +41,70 @@ const severityStyles = {
   low: 'bg-slate-100 text-slate-800',
 } as const;
 
+const lottingModeConfig: Record<
+  LottingMode,
+  {
+    label: string;
+    title: string;
+    description: string;
+    filterPatch: Partial<LottingFilterState>;
+  }
+> = {
+  quick: {
+    label: 'Modo rápido',
+    title: 'Seleção assistida para operação imediata',
+    description:
+      'Mantém o fluxo padrão do BidExpert para selecionar ativos elegíveis e gerar lotes com poucos cliques.',
+    filterPatch: {},
+  },
+  spreadsheet: {
+    label: 'Modo planilha operacional',
+    title: 'Revisão em massa com contexto persistido',
+    description:
+      'Prioriza a conferência em massa. Ao ativar este modo, o operador já vê também ativos previamente agrupados para reconciliação rápida.',
+    filterPatch: {
+      includeGroupedAssets: true,
+    },
+  },
+  ai: {
+    label: 'Modo IA assistida',
+    title: 'Priorização por alertas e sinais inteligentes',
+    description:
+      'Destaca ativos sinalizados pela IA e coloca o painel de alertas judiciais antes da grade para acelerar a triagem operacional.',
+    filterPatch: {
+      onlyHighlighted: true,
+    },
+  },
+};
+
+type LottingAutosaveState = 'idle' | 'saving' | 'saved' | 'error';
+
 const formatCurrency = (value: number) => value.toLocaleString('pt-BR', { style: 'currency', currency: 'BRL' });
+
+const formatSavedAt = (timestamp: string | null) => {
+  if (!timestamp) {
+    return null;
+  }
+
+  const date = new Date(timestamp);
+  if (Number.isNaN(date.getTime())) {
+    return null;
+  }
+
+  return date.toLocaleTimeString('pt-BR', {
+    hour: '2-digit',
+    minute: '2-digit',
+  });
+};
 
 export default function LoteamentoPage() {
   const [processes, setProcesses] = useState<JudicialProcess[]>([]);
   const [auctions, setAuctions] = useState<Auction[]>([]);
-  const [filters, setFilters] = useState<LottingFilterState>({ includeGroupedAssets: false, onlyHighlighted: false, minimumValuation: 0 });
+  const [filters, setFilters] = useState<LottingFilterState>(getDefaultLottingFilters());
+  const [lottingMode, setLottingMode] = useState<LottingMode>('quick');
+  const [autosaveState, setAutosaveState] = useState<LottingAutosaveState>('idle');
+  const [lastSavedAt, setLastSavedAt] = useState<string | null>(null);
+  const [hasLoadedPreferences, setHasLoadedPreferences] = useState(false);
   const [snapshot, setSnapshot] = useState<LottingSnapshot | null>(null);
   const [isLoading, setIsLoading] = useState(true);
   const [isSnapshotLoading, setIsSnapshotLoading] = useState(true);
@@ -61,6 +124,24 @@ export default function LoteamentoPage() {
     () => buildJudicialProcessSelectorOptions(processes),
     [processes]
   );
+  const activeModeConfig = lottingModeConfig[lottingMode];
+  const showInsightsFirst = lottingMode === 'ai';
+  const autosaveLabel = useMemo(() => {
+    if (autosaveState === 'saving') {
+      return 'Salvando preferências...';
+    }
+
+    if (autosaveState === 'error') {
+      return 'Falha ao salvar preferências';
+    }
+
+    const savedAt = formatSavedAt(lastSavedAt);
+    if (savedAt) {
+      return `Preferências salvas às ${savedAt}`;
+    }
+
+    return 'Auto-save ativo';
+  }, [autosaveState, lastSavedAt]);
 
   const auctionOptions = useMemo(() => auctions.map(a => {
     const formattedDate = a.auctionDate ? new Date(a.auctionDate).toLocaleDateString('pt-BR') : 'Data não definida';
@@ -103,6 +184,53 @@ export default function LoteamentoPage() {
   useEffect(() => {
     fetchInitialData();
   }, [fetchInitialData]);
+
+  useEffect(() => {
+    if (typeof window === 'undefined') {
+      return;
+    }
+
+    const storedPreferences = loadLottingPreferences(window.localStorage);
+
+    setLottingMode(storedPreferences.mode);
+    setFilters((previous) => ({
+      ...previous,
+      ...storedPreferences.filters,
+    }));
+    setLastSavedAt(storedPreferences.updatedAt ?? null);
+    setAutosaveState(storedPreferences.updatedAt ? 'saved' : 'idle');
+    setHasLoadedPreferences(true);
+  }, []);
+
+  useEffect(() => {
+    if (!hasLoadedPreferences || typeof window === 'undefined') {
+      return;
+    }
+
+    try {
+      setAutosaveState('saving');
+
+      const savedPreferences = saveLottingPreferences(
+        {
+          mode: lottingMode,
+          filters,
+        },
+        window.localStorage,
+      );
+
+      setLastSavedAt(savedPreferences.updatedAt ?? null);
+      setAutosaveState('saved');
+    } catch (error) {
+      console.error(error);
+      setAutosaveState('error');
+    }
+  }, [
+    filters.includeGroupedAssets,
+    filters.minimumValuation,
+    filters.onlyHighlighted,
+    hasLoadedPreferences,
+    lottingMode,
+  ]);
 
   useEffect(() => {
     fetchSnapshot(filters);
@@ -180,6 +308,14 @@ export default function LoteamentoPage() {
 
   const handleFilterChange = (partial: Partial<LottingFilterState>) => {
     setFilters(prev => ({ ...prev, ...partial }));
+  };
+
+  const handleModeChange = (nextMode: LottingMode) => {
+    setLottingMode(nextMode);
+    setFilters((previous) => ({
+      ...previous,
+      ...lottingModeConfig[nextMode].filterPatch,
+    }));
   };
 
   const handleRefreshSnapshot = () => fetchSnapshot(filters);
@@ -305,10 +441,56 @@ export default function LoteamentoPage() {
                 />
               </div>
             </div>
+            <Card data-ai-id="lotting-mode-card">
+              <CardHeader className="flex flex-col gap-3 lg:flex-row lg:items-start lg:justify-between">
+                <div>
+                  <CardTitle className="text-base">Modos operacionais</CardTitle>
+                  <CardDescription>
+                    {activeModeConfig.title}. {activeModeConfig.description}
+                  </CardDescription>
+                </div>
+                <Badge variant="secondary" data-ai-id="lotting-autosave-badge">
+                  {autosaveLabel}
+                </Badge>
+              </CardHeader>
+              <CardContent className="space-y-4">
+                <div
+                  aria-label="Modo de loteamento"
+                  className="grid gap-2 md:grid-cols-3"
+                  role="radiogroup"
+                >
+                  {(Object.entries(lottingModeConfig) as Array<[LottingMode, (typeof lottingModeConfig)[LottingMode]]>).map(([modeKey, config]) => (
+                    <Button
+                      key={modeKey}
+                      aria-checked={lottingMode === modeKey}
+                      className="justify-start"
+                      data-ai-id={`lotting-mode-${modeKey}`}
+                      onClick={() => handleModeChange(modeKey)}
+                      role="radio"
+                      type="button"
+                      variant={lottingMode === modeKey ? 'default' : 'outline'}
+                    >
+                      {config.label}
+                    </Button>
+                  ))}
+                </div>
+
+                <div className="rounded-lg border bg-muted/40 p-3" data-ai-id="lotting-mode-summary">
+                  <p className="text-sm font-medium">{activeModeConfig.title}</p>
+                  <p className="text-sm text-muted-foreground">{activeModeConfig.description}</p>
+                </div>
+              </CardContent>
+            </Card>
             <Card data-ai-id="lotting-toggle-card">
               <CardHeader>
                 <CardTitle className="text-base flex items-center gap-2"><Sparkles className="h-4 w-4 text-primary" /> Preferências inteligentes</CardTitle>
-                <CardDescription>Refine os ativos sugeridos pela IA.</CardDescription>
+                <CardDescription>
+                  {lottingMode === 'spreadsheet'
+                    ? 'As preferências abaixo ficam persistidas localmente para apoiar a revisão operacional em massa.'
+                    : lottingMode === 'ai'
+                      ? 'As preferências abaixo refinam a triagem de ativos sinalizados e alimentam a priorização assistida.'
+                      : 'Refine os ativos sugeridos pela IA.'}
+                </CardDescription>
               </CardHeader>
               <CardContent className="space-y-4">
                 <div className="flex items-center justify-between">
@@ -316,7 +498,7 @@ export default function LoteamentoPage() {
                     <p className="text-sm font-medium">Incluir ativos já loteados</p>
                     <p className="text-xs text-muted-foreground">Mostra ativos em lotes existentes.</p>
                   </div>
-                  <Switch checked={!!filters.includeGroupedAssets} onCheckedChange={(value) => handleFilterChange({ includeGroupedAssets: value })} data-ai-id="lotting-toggle-include-grouped" />
+                  <Switch aria-label="Incluir ativos já loteados" checked={!!filters.includeGroupedAssets} onCheckedChange={(value) => handleFilterChange({ includeGroupedAssets: value })} data-ai-id="lotting-toggle-include-grouped" />
                 </div>
                 <Separator />
                 <div className="flex items-center justify-between">
@@ -324,7 +506,7 @@ export default function LoteamentoPage() {
                     <p className="text-sm font-medium">Somente ativos sinalizados</p>
                     <p className="text-xs text-muted-foreground">Usa dicas de IA para priorizar ativos.</p>
                   </div>
-                  <Switch checked={!!filters.onlyHighlighted} onCheckedChange={(value) => handleFilterChange({ onlyHighlighted: value })} data-ai-id="lotting-toggle-ai" />
+                  <Switch aria-label="Somente ativos sinalizados" checked={!!filters.onlyHighlighted} onCheckedChange={(value) => handleFilterChange({ onlyHighlighted: value })} data-ai-id="lotting-toggle-ai" />
                 </div>
                 <Separator />
                 <div>
@@ -347,7 +529,13 @@ export default function LoteamentoPage() {
               <CardHeader className="flex flex-row justify-between items-center">
                 <div>
                   <CardTitle className="text-lg flex items-center gap-2" data-ai-id="lotting-assets-title"><Package className="h-4 w-4" /> Ativos compatíveis</CardTitle>
-                  <CardDescription>Selecione ativos para loteamento.</CardDescription>
+                  <CardDescription>
+                    {lottingMode === 'spreadsheet'
+                      ? 'Revise os ativos em massa e mantenha o contexto do operador salvo automaticamente entre sessões.'
+                      : lottingMode === 'ai'
+                        ? 'Selecione ativos para loteamento com prioridade nos sinais inteligentes e alertas judiciais.'
+                        : 'Selecione ativos para loteamento.'}
+                  </CardDescription>
                 </div>
                 <div className="flex gap-2 flex-wrap">
                   <Button onClick={handleCreateIndividualLotsClick} variant="outline" disabled={selectedAssets.length === 0 || isSubmitting} data-ai-id="lotting-action-individual">
@@ -382,10 +570,19 @@ export default function LoteamentoPage() {
 
             {renderKpis()}
 
-            <div className="grid lg:grid-cols-2 gap-4">
-              {renderAlerts()}
-              {renderLotsSummary()}
-            </div>
+            {showInsightsFirst ? (
+              <div className="grid lg:grid-cols-2 gap-4">
+                {renderAlerts()}
+                {renderLotsSummary()}
+              </div>
+            ) : null}
+
+            {!showInsightsFirst ? (
+              <div className="grid lg:grid-cols-2 gap-4">
+                {renderAlerts()}
+                {renderLotsSummary()}
+              </div>
+            ) : null}
           </CardContent>
         </Card>
       </div>

--- a/src/app/admin/lotting/page.tsx
+++ b/src/app/admin/lotting/page.tsx
@@ -25,6 +25,10 @@ import CreateLotFromAssetsModal from '@/components/admin/lotting/create-lot-moda
 import AssetDetailsModal from '@/components/admin/assets/asset-details-modal';
 import { createColumns } from '@/components/admin/lotting/columns';
 import EntitySelector from '@/components/ui/entity-selector';
+import {
+  buildJudicialProcessSelectorOptions,
+  judicialProcessSelectorColumns,
+} from '@/components/admin/judicial-processes/judicial-process-selector-config';
 
 const severityStyles = {
   high: 'bg-red-100 text-red-800',
@@ -53,10 +57,10 @@ export default function LoteamentoPage() {
   const selectedAuction = auctions.find(a => a.id === selectedAuctionId);
   const assets = snapshot?.assets ?? [];
 
-  const processOptions = useMemo(() => processes.map(p => ({
-    value: p.id,
-    label: `${p.processNumber} · ${(p.assetCount ?? 0).toString()} bens · ${(p.lotCount ?? 0).toString()} lotes${p.courtName ? ` · ${p.courtName}` : ''}`,
-  })), [processes]);
+  const processOptions = useMemo(
+    () => buildJudicialProcessSelectorOptions(processes),
+    [processes]
+  );
 
   const auctionOptions = useMemo(() => auctions.map(a => {
     const formattedDate = a.auctionDate ? new Date(a.auctionDate).toLocaleDateString('pt-BR') : 'Data não definida';
@@ -279,10 +283,12 @@ export default function LoteamentoPage() {
                   onChange={(value) => handleFilterChange({ judicialProcessId: value || undefined })}
                   options={processOptions}
                   placeholder={isLoading ? 'Carregando...' : 'Selecione um processo'}
-                  searchPlaceholder="Buscar processo..."
+                  searchPlaceholder="Buscar processo, comitente, vara, comarca, tribunal, partes, matrícula, registro ou CNJ..."
                   emptyStateMessage="Nenhum processo encontrado"
                   entityName="processo judicial"
                   disabled={isLoading}
+                  displayColumns={judicialProcessSelectorColumns}
+                  dialogDescription="Selecione o processo judicial correto. O grid mostra número, comitente, vara, comarca, tribunal, partes e os totais de bens/lotes para evitar seleção ambígua."
                 />
               </div>
               <div className="space-y-2">

--- a/src/app/auctions/[auctionId]/monitor/monitor-auditorium-client.tsx
+++ b/src/app/auctions/[auctionId]/monitor/monitor-auditorium-client.tsx
@@ -71,6 +71,9 @@ export default function MonitorAuditoriumClient({
     const prevLotStatusRef = useRef<string>(initialCurrentLot.status);
 
     // V2 Real-time hook
+    const realtimeLotId = currentLot.id || currentLot.publicId;
+    const realtimeAuctionId = auction.id || auction.publicId;
+
     const {
         bids: realtimeBids,
         lotState,
@@ -79,8 +82,8 @@ export default function MonitorAuditoriumClient({
         connectionType,
         clearSoftCloseAlert,
     } = useRealtimeBids({
-        lotId: currentLot.publicId || currentLot.id,
-        auctionId: auction.publicId || auction.id,
+        lotId: realtimeLotId,
+        auctionId: realtimeAuctionId,
         enabled: true,
         strategy: communicationStrategy,
         pollingIntervalMs: 3000,
@@ -127,8 +130,8 @@ export default function MonitorAuditoriumClient({
         if (lotState) {
             setCurrentLot(prev => ({
                 ...prev,
-                price: lotState.price,
-                bidsCount: lotState.bidsCount,
+                price: lotState.price ?? prev.price,
+                bidsCount: Math.max(prev.bidsCount ?? 0, lotState.bidsCount ?? 0),
                 status: lotState.status as any,
                 endDate: lotState.endDate ? new Date(lotState.endDate) : prev.endDate,
             }));
@@ -184,6 +187,12 @@ export default function MonitorAuditoriumClient({
         null,
         bidHistory.length,
         bidHistory[0]?.amount ?? currentLot?.price ?? null
+    );
+
+    const displayBidCount = Math.max(
+        lotState?.bidsCount ?? 0,
+        currentLot.bidsCount ?? 0,
+        bidHistory.length
     );
 
     const handleLotSelect = useCallback((lot: Lot) => {
@@ -327,7 +336,7 @@ export default function MonitorAuditoriumClient({
                                 user={realtimeBids[0]?.bidderDisplay || bidHistory[0]?.bidderDisplay || '---'}
                                 amount={realtimeBids[0]?.amount || bidHistory[0]?.amount || currentLot.price || 0}
                                 endDate={currentLot.endDate}
-                                bidCount={lotState?.bidsCount ?? bidHistory.length}
+                                bidCount={displayBidCount}
                             />
                             <MonitorSoftCloseAlert
                                 softCloseEvent={softCloseAlert}

--- a/src/components/admin/auctions/auction-audit-summary.tsx
+++ b/src/components/admin/auctions/auction-audit-summary.tsx
@@ -1,0 +1,96 @@
+/**
+ * @fileoverview Resumo enxuto de auditoria para superfícies administrativas de leilão.
+ */
+
+import React from 'react';
+import Link from 'next/link';
+import { History } from 'lucide-react';
+import { Button } from '@/components/ui/button';
+import { Card, CardContent, CardDescription, CardHeader, CardTitle } from '@/components/ui/card';
+
+interface AuctionAuditSummaryProps {
+  createdByUserId?: string | bigint | null;
+  updatedAt?: string | Date | null;
+  submittedAt?: string | Date | null;
+  validatedAt?: string | Date | null;
+  validatedBy?: string | bigint | null;
+  historyHref?: string;
+}
+
+const formatter = new Intl.DateTimeFormat('pt-BR', {
+  dateStyle: 'short',
+  timeStyle: 'short',
+});
+
+function normalizeIdentifier(value?: string | bigint | null): string {
+  if (value === null || value === undefined || value === '') {
+    return 'Não informado';
+  }
+
+  return value.toString();
+}
+
+function formatDateTime(value?: string | Date | null): string {
+  if (!value) {
+    return 'Não informado';
+  }
+
+  const parsed = value instanceof Date ? value : new Date(value);
+  if (Number.isNaN(parsed.getTime())) {
+    return 'Não informado';
+  }
+
+  return formatter.format(parsed);
+}
+
+export function AuctionAuditSummary({
+  createdByUserId,
+  updatedAt,
+  submittedAt,
+  validatedAt,
+  validatedBy,
+  historyHref,
+}: AuctionAuditSummaryProps) {
+  const hasAuditData = Boolean(createdByUserId || updatedAt || submittedAt || validatedAt || validatedBy || historyHref);
+
+  if (!hasAuditData) {
+    return null;
+  }
+
+  const items = [
+    { id: 'created-by', label: 'Criado por', value: normalizeIdentifier(createdByUserId) },
+    { id: 'updated-at', label: 'Atualizado em', value: formatDateTime(updatedAt) },
+    { id: 'submitted-at', label: 'Enviado para validação', value: formatDateTime(submittedAt) },
+    { id: 'validated-by', label: 'Validado por', value: normalizeIdentifier(validatedBy) },
+    { id: 'validated-at', label: 'Validado em', value: formatDateTime(validatedAt) },
+  ];
+
+  return (
+    <Card data-ai-id="auction-audit-summary">
+      <CardHeader className="flex flex-col gap-3 md:flex-row md:items-start md:justify-between">
+        <div>
+          <CardTitle>Auditoria mínima</CardTitle>
+          <CardDescription>Rastro essencial de criação, atualização e validação do leilão atual.</CardDescription>
+        </div>
+        {historyHref ? (
+          <Button asChild variant="outline" size="sm">
+            <Link href={historyHref} data-ai-id="auction-audit-summary-history-link">
+              <History className="mr-2 h-4 w-4" />
+              Abrir histórico completo
+            </Link>
+          </Button>
+        ) : null}
+      </CardHeader>
+      <CardContent>
+        <div className="grid gap-3 md:grid-cols-2 xl:grid-cols-5">
+          {items.map((item) => (
+            <div key={item.id} className="rounded-md border p-3" data-ai-id={`auction-audit-item-${item.id}`}>
+              <p className="text-xs font-medium uppercase tracking-wide text-muted-foreground">{item.label}</p>
+              <p className="mt-1 text-sm font-semibold break-all">{item.value}</p>
+            </div>
+          ))}
+        </div>
+      </CardContent>
+    </Card>
+  );
+}

--- a/src/components/admin/judicial-processes/judicial-process-selector-config.tsx
+++ b/src/components/admin/judicial-processes/judicial-process-selector-config.tsx
@@ -1,5 +1,6 @@
 /**
- * @fileoverview Configuração compartilhada do grid/modal de seleção de Processo Judicial.
+ * @fileoverview Configuração compartilhada do seletor de processos judiciais.
+ * Centraliza as colunas e a montagem de opções ricas para evitar seleções ambíguas.
  */
 
 import type { JudicialProcess } from '@/types';

--- a/src/lib/bidding-eligibility.ts
+++ b/src/lib/bidding-eligibility.ts
@@ -30,8 +30,8 @@ export interface BidEligibilityState {
   description: string;
 }
 
-const ACTIVE_AUCTION_STATUSES = new Set<AuctionStatus>(['ABERTO', 'ABERTO_PARA_LANCES']);
-const OPEN_LOT_STATUS: LotStatus = 'ABERTO_PARA_LANCES';
+const ACTIVE_AUCTION_STATUSES = new Set<AuctionStatus>(['ABERTO', 'ABERTO_PARA_LANCES', 'EM_PREGAO']);
+const ACTIVE_LOT_STATUSES = new Set<LotStatus>(['ABERTO_PARA_LANCES', 'EM_PREGAO']);
 
 const getDocumentationCopy = (status?: UserHabilitationStatus | null) => {
   switch (status) {
@@ -78,7 +78,7 @@ export const getBidEligibilityState = ({
     };
   }
 
-  if (lotStatus && lotStatus !== OPEN_LOT_STATUS) {
+  if (lotStatus && !ACTIVE_LOT_STATUSES.has(lotStatus)) {
     return {
       canBid: false,
       canPlaceMaxBid: false,

--- a/src/lib/lotting/preferences.ts
+++ b/src/lib/lotting/preferences.ts
@@ -1,0 +1,109 @@
+/**
+ * @fileoverview Persistência local das preferências operacionais do loteamento.
+ */
+
+import type { LottingFilterState, LottingMode } from '@/types/lotting';
+
+export const LOTTING_PREFERENCES_STORAGE_KEY = 'bidexpert.admin.lotting.preferences.v1';
+
+export interface LottingPreferences {
+  mode: LottingMode;
+  filters: LottingFilterState;
+  updatedAt?: string;
+}
+
+const DEFAULT_FILTERS: LottingFilterState = {
+  includeGroupedAssets: false,
+  onlyHighlighted: false,
+  minimumValuation: 0,
+};
+
+export function getDefaultLottingFilters(): LottingFilterState {
+  return {
+    ...DEFAULT_FILTERS,
+  };
+}
+
+function normalizeMode(value: unknown): LottingMode {
+  if (value === 'spreadsheet' || value === 'ai') {
+    return value;
+  }
+
+  return 'quick';
+}
+
+function normalizeFilters(raw: unknown): LottingFilterState {
+  if (!raw || typeof raw !== 'object') {
+    return getDefaultLottingFilters();
+  }
+
+  const filters = raw as LottingFilterState;
+
+  return {
+    includeGroupedAssets:
+      typeof filters.includeGroupedAssets === 'boolean'
+        ? filters.includeGroupedAssets
+        : DEFAULT_FILTERS.includeGroupedAssets,
+    onlyHighlighted:
+      typeof filters.onlyHighlighted === 'boolean'
+        ? filters.onlyHighlighted
+        : DEFAULT_FILTERS.onlyHighlighted,
+    minimumValuation:
+      typeof filters.minimumValuation === 'number' && Number.isFinite(filters.minimumValuation)
+        ? Math.max(0, filters.minimumValuation)
+        : DEFAULT_FILTERS.minimumValuation,
+  };
+}
+
+export function normalizeLottingPreferences(raw: unknown): LottingPreferences {
+  if (!raw || typeof raw !== 'object') {
+    return {
+      mode: 'quick',
+      filters: getDefaultLottingFilters(),
+    };
+  }
+
+  const preferences = raw as LottingPreferences;
+
+  return {
+    mode: normalizeMode(preferences.mode),
+    filters: normalizeFilters(preferences.filters),
+    updatedAt:
+      typeof preferences.updatedAt === 'string' && preferences.updatedAt.length > 0
+        ? preferences.updatedAt
+        : undefined,
+  };
+}
+
+export function loadLottingPreferences(storage?: Pick<Storage, 'getItem'> | null): LottingPreferences {
+  if (!storage) {
+    return normalizeLottingPreferences(undefined);
+  }
+
+  try {
+    const raw = storage.getItem(LOTTING_PREFERENCES_STORAGE_KEY);
+    if (!raw) {
+      return normalizeLottingPreferences(undefined);
+    }
+
+    return normalizeLottingPreferences(JSON.parse(raw));
+  } catch {
+    return normalizeLottingPreferences(undefined);
+  }
+}
+
+export function saveLottingPreferences(
+  preferences: LottingPreferences,
+  storage?: Pick<Storage, 'setItem'> | null,
+): LottingPreferences {
+  const normalized = normalizeLottingPreferences({
+    ...preferences,
+    updatedAt: new Date().toISOString(),
+  });
+
+  if (storage) {
+    storage.setItem(LOTTING_PREFERENCES_STORAGE_KEY, JSON.stringify(normalized));
+  }
+
+  return normalized;
+}

--- a/src/types/lotting.ts
+++ b/src/types/lotting.ts
@@ -9,6 +9,8 @@ export type LottingFilterState = {
   minimumValuation?: number;
 };
 
+export type LottingMode = 'quick' | 'spreadsheet' | 'ai';
+
 export type LottingKpi = {
   id: string;
   label: string;

--- a/tests/e2e/admin/judicial-process-selector-columns.spec.ts
+++ b/tests/e2e/admin/judicial-process-selector-columns.spec.ts
@@ -4,14 +4,10 @@
 
 import { expect, test } from '@playwright/test';
 
-import { loginAsAdmin } from '../helpers/auth-helper';
-
-const BASE_URL = process.env.PLAYWRIGHT_TEST_BASE_URL ?? 'http://demo.localhost:9006';
+const BASE_URL = process.env.PLAYWRIGHT_TEST_BASE_URL ?? process.env.BASE_URL ?? 'http://demo.localhost:9006';
 
 test('admin auction form mostra colunas ampliadas no selector de processo judicial', async ({ page }) => {
   test.setTimeout(240_000);
-
-  await loginAsAdmin(page, BASE_URL);
 
   await page.request.get(`${BASE_URL}/admin/auctions/new`, {
     failOnStatusCode: false,

--- a/tests/e2e/admin/lotting-modes-persistence.spec.ts
+++ b/tests/e2e/admin/lotting-modes-persistence.spec.ts
@@ -1,0 +1,39 @@
+/**
+ * @fileoverview Regressão E2E para os modos operacionais do loteamento.
+ */
+
+import { expect, test } from '@playwright/test';
+
+const BASE_URL = process.env.PLAYWRIGHT_TEST_BASE_URL ?? process.env.BASE_URL ?? 'http://demo.localhost:9027';
+
+test('modo do loteamento persiste com auto-save e reaplica presets operacionais', async ({ page }) => {
+  test.setTimeout(240_000);
+
+  await page.goto(`${BASE_URL}/admin/lotting`, {
+    waitUntil: 'domcontentloaded',
+    timeout: 180_000,
+  });
+
+  await expect(page.locator('[data-ai-id="lotting-mode-card"]')).toBeVisible({ timeout: 30_000 });
+
+  const aiMode = page.getByRole('radio', { name: /modo ia assistida/i });
+  const spreadsheetMode = page.getByRole('radio', { name: /modo planilha operacional/i });
+  const autosaveBadge = page.locator('[data-ai-id="lotting-autosave-badge"]');
+  const highlightedToggle = page.locator('[data-ai-id="lotting-toggle-ai"]');
+  const includeGroupedToggle = page.locator('[data-ai-id="lotting-toggle-include-grouped"]');
+
+  await aiMode.click();
+  await expect(aiMode).toHaveAttribute('aria-checked', 'true');
+  await expect(highlightedToggle).toHaveAttribute('aria-checked', 'true');
+  await expect(autosaveBadge).toContainText(/salvas|salvando|auto-save/i);
+
+  await spreadsheetMode.click();
+  await expect(spreadsheetMode).toHaveAttribute('aria-checked', 'true');
+  await expect(includeGroupedToggle).toHaveAttribute('aria-checked', 'true');
+  await expect(page.locator('[data-ai-id="lotting-mode-summary"]')).toContainText(/revisão em massa/i);
+
+  await page.reload({ waitUntil: 'domcontentloaded' });
+
+  await expect(page.getByRole('radio', { name: /modo planilha operacional/i })).toHaveAttribute('aria-checked', 'true');
+  await expect(page.locator('[data-ai-id="lotting-autosave-badge"]')).toContainText(/salvas|auto-save/i);
+});

--- a/tests/e2e/global-setup.ts
+++ b/tests/e2e/global-setup.ts
@@ -65,7 +65,7 @@ function resolveTenantPattern(baseUrl: URL) {
 }
 
 async function globalSetup(config: FullConfig) {
-  const baseURL = process.env.BASE_URL || config.projects[0].use.baseURL || 'http://localhost:9005';
+  const baseURL = (process.env.BASE_URL || config.projects[0].use.baseURL || 'http://localhost:9005').trim();
   const baseUrlObject = new URL(baseURL);
   const isDemoTenant = baseUrlObject.hostname.startsWith('demo.') || baseUrlObject.hostname.includes('demo');
   const bypassHeaders = buildBypassHeaders();

--- a/tests/e2e/helpers/pregao-multiperfil-fixture.ts
+++ b/tests/e2e/helpers/pregao-multiperfil-fixture.ts
@@ -1,0 +1,811 @@
+/**
+ * @fileoverview Fixture E2E para pregão filmado multi-perfil.
+ * Cria atores reais por perfil, habilita compradores, executa transições pela
+ * máquina de estado oficial e dispara lances pelo BidEngineV2.
+ */
+
+import { expect, type BrowserContext, type Page } from '@playwright/test';
+import { Prisma, PrismaClient } from '@prisma/client';
+import bcryptjs from 'bcryptjs';
+import { createHash, randomUUID } from 'node:crypto';
+import { SignJWT } from 'jose';
+import { auctionStateMachine } from '@/lib/auction-state-machine/auction-state.service';
+import { lotStateMachine } from '@/lib/auction-state-machine/lot-state.service';
+import { BidEngineV2 } from '@/services/bid-engine-v2.service';
+
+import { selectTenant } from './auth-helper';
+
+export const PREGAO_BUYER_COUNT = 10;
+export const PREGAO_INITIAL_PRICE = 5_000;
+export const PREGAO_BID_INCREMENT = 500;
+export const PREGAO_DEFAULT_ROUNDS = Number(process.env.PREGAO_BID_ROUNDS || '3');
+export const PREGAO_TEST_PASSWORD = 'Pregao@12345';
+
+export type PregaoActorKind = 'auctionAgent' | 'admin' | 'auctioneer' | 'buyer' | 'analyst';
+
+export interface PregaoActor {
+  key: string;
+  kind: PregaoActorKind;
+  label: string;
+  email: string;
+  password: string;
+  roles: string[];
+  userId?: bigint;
+}
+
+export interface PregaoBuyerActor extends PregaoActor {
+  kind: 'buyer';
+  buyerNumber: number;
+  bidderAlias: string;
+  bidderProfileId?: bigint;
+}
+
+export interface PregaoActorMatrix {
+  auctionAgent: PregaoActor;
+  admin: PregaoActor;
+  auctioneer: PregaoActor;
+  analyst: PregaoActor;
+  buyers: PregaoBuyerActor[];
+}
+
+export interface PregaoBidScheduleEntry {
+  round: number;
+  buyerNumber: number;
+  buyerKey: string;
+  bidderAlias: string;
+  amount: number;
+  idempotencyKey: string;
+}
+
+export interface PregaoBidResult extends PregaoBidScheduleEntry {
+  bidId: string;
+  currentBid: number;
+}
+
+export interface PregaoWinnerSummary {
+  buyerKey: string;
+  buyerNumber: number;
+  bidderAlias: string;
+  amount: number;
+}
+
+export interface PregaoFixture {
+  runId: string;
+  tenantId: bigint;
+  auctionId: bigint;
+  auctionPublicId: string;
+  lotId: bigint;
+  lotPublicId: string;
+  auctionStageId: bigint;
+  actors: PregaoActorMatrix;
+  bidSchedule: PregaoBidScheduleEntry[];
+  createdUserIds: bigint[];
+}
+
+const ROLE_PERMISSIONS: Record<string, string[]> = {
+  ADMIN: ['manage_all', 'CAN_VALIDATE_AUCTION', 'CAN_CANCEL_OR_CLOSE'],
+  LEILOEIRO: ['conduct_auctions', 'auctions:manage_assigned', 'lots:manage_assigned', 'CAN_CANCEL_OR_CLOSE'],
+  COMPRADOR: ['place_bids', 'view_auctions', 'view_lots'],
+  VENDEDOR: ['consignor_dashboard:view', 'auctions:manage_own', 'lots:manage_own'],
+  AVALIADOR: ['documents:generate_report', 'reports:write', 'billing:read'],
+};
+
+const STATE_ADMIN_PERMISSIONS = ['CAN_VALIDATE_AUCTION', 'CAN_CANCEL_OR_CLOSE'];
+const STATE_AUCTIONEER_PERMISSIONS = ['CAN_CANCEL_OR_CLOSE'];
+
+export function createPregaoRunId(): string {
+  return `pregao-${Date.now().toString(36)}-${randomUUID().slice(0, 8)}`;
+}
+
+export function buildPregaoActorMatrix(runId: string): PregaoActorMatrix {
+  const suffix = runId.toLowerCase().replace(/[^a-z0-9-]/g, '-');
+  const actor = (kind: PregaoActorKind, label: string, roles: string[]): PregaoActor => ({
+    key: kind,
+    kind,
+    label,
+    email: `pregao.${kind}.${suffix}@bidexpert.test`,
+    password: PREGAO_TEST_PASSWORD,
+    roles,
+  });
+
+  return {
+    auctionAgent: actor('auctionAgent', 'Agente de Leilao Pregao Filmado', ['VENDEDOR']),
+    admin: actor('admin', 'Administrador Pregao Filmado', ['ADMIN']),
+    auctioneer: actor('auctioneer', 'Leiloeiro Pregao Filmado', ['LEILOEIRO']),
+    analyst: actor('analyst', 'Analista Pregao Filmado', ['AVALIADOR']),
+    buyers: Array.from({ length: PREGAO_BUYER_COUNT }, (_, index) => {
+      const buyerNumber = index + 1;
+      return {
+        key: `buyer-${buyerNumber.toString().padStart(2, '0')}`,
+        kind: 'buyer',
+        label: `Comprador Pregao Filmado ${buyerNumber.toString().padStart(2, '0')}`,
+        email: `pregao.buyer.${suffix}.${buyerNumber}@bidexpert.test`,
+        password: PREGAO_TEST_PASSWORD,
+        roles: ['COMPRADOR'],
+        buyerNumber,
+        bidderAlias: `Arrematante ${buyerNumber.toString().padStart(2, '0')}`,
+      } satisfies PregaoBuyerActor;
+    }),
+  };
+}
+
+export function buildPregaoBidSchedule(
+  buyers: PregaoBuyerActor[],
+  options: { runId: string; rounds?: number; initialPrice?: number; bidIncrement?: number },
+): PregaoBidScheduleEntry[] {
+  const rounds = options.rounds ?? PREGAO_DEFAULT_ROUNDS;
+  const initialPrice = options.initialPrice ?? PREGAO_INITIAL_PRICE;
+  const bidIncrement = options.bidIncrement ?? PREGAO_BID_INCREMENT;
+  const schedule: PregaoBidScheduleEntry[] = [];
+  let amount = initialPrice;
+
+  for (let round = 1; round <= rounds; round += 1) {
+    for (const buyer of buyers) {
+      amount += bidIncrement;
+      schedule.push({
+        round,
+        buyerNumber: buyer.buyerNumber,
+        buyerKey: buyer.key,
+        bidderAlias: buyer.bidderAlias,
+        amount,
+        idempotencyKey: makeIdempotencyKey(options.runId, round, buyer.key, amount),
+      });
+    }
+  }
+
+  return schedule;
+}
+
+export function resolvePregaoWinner(schedule: PregaoBidScheduleEntry[]): PregaoWinnerSummary {
+  if (schedule.length === 0) {
+    throw new Error('Agenda de lances vazia.');
+  }
+
+  const winner = schedule.reduce((currentWinner, entry) => (
+    entry.amount >= currentWinner.amount ? entry : currentWinner
+  ), schedule[0]);
+
+  return {
+    buyerKey: winner.buyerKey,
+    buyerNumber: winner.buyerNumber,
+    bidderAlias: winner.bidderAlias,
+    amount: winner.amount,
+  };
+}
+
+export function groupPregaoScheduleByRound(schedule: PregaoBidScheduleEntry[]): PregaoBidScheduleEntry[][] {
+  const groups = new Map<number, PregaoBidScheduleEntry[]>();
+  for (const entry of schedule) {
+    const existing = groups.get(entry.round) ?? [];
+    existing.push(entry);
+    groups.set(entry.round, existing);
+  }
+  return Array.from(groups.values());
+}
+
+export function parseBrazilianCurrency(value: string | null | undefined): number {
+  if (!value) {
+    return 0;
+  }
+
+  const normalized = value.replace(/[^0-9,.-]/g, '').replace(/\./g, '').replace(',', '.');
+  const parsed = Number(normalized);
+  return Number.isFinite(parsed) ? parsed : 0;
+}
+
+export async function loginPregaoActor(page: Page, actor: PregaoActor, baseUrl: string): Promise<void> {
+  await page.context().request.get(`${baseUrl}/api/public/tenants`, { timeout: 30_000 }).catch(() => undefined);
+  await page.goto(`${baseUrl}/auth/login`, { waitUntil: 'domcontentloaded', timeout: 120_000 });
+
+  const emailInput = page.locator('[data-ai-id="auth-login-email-input"], input[type="email"]').first();
+  const passwordInput = page.locator('[data-ai-id="auth-login-password-input"], input[type="password"]').first();
+  const submitButton = page.locator('[data-ai-id="auth-login-submit-button"], button[type="submit"]').first();
+
+  await emailInput.waitFor({ state: 'visible', timeout: 60_000 });
+  await page.waitForFunction(() => {
+    const tenantTrigger = document.querySelector('[data-ai-id="auth-login-tenant-select"]');
+    const lockedText = document.body.textContent?.includes('Você está acessando:');
+    return Boolean(tenantTrigger && lockedText);
+  }, { timeout: 45_000 }).catch(() => undefined);
+  await selectTenant(page, /BidExpert Demo|BidExpert/i);
+  await emailInput.fill(actor.email);
+  await passwordInput.fill(actor.password);
+  await expect(emailInput).toHaveValue(actor.email, { timeout: 10_000 });
+  await expect(passwordInput).toHaveValue(actor.password, { timeout: 10_000 });
+
+  await page.waitForFunction(() => {
+    const submit = document.querySelector('[data-ai-id="auth-login-submit-button"]') as HTMLButtonElement | null;
+    return submit ? !submit.disabled : true;
+  }, { timeout: 10_000 }).catch(() => undefined);
+
+  const responsePromise = page.waitForResponse(
+    (response) => response.url().includes('/auth/login') && response.request().method() === 'POST',
+    { timeout: 45_000 },
+  ).catch(() => null);
+
+  const submitted = await page.evaluate(() => {
+    const form = document.querySelector('[data-ai-id="auth-login-form"]') as HTMLFormElement | null;
+    if (form) {
+      form.requestSubmit();
+      return 'requestSubmit';
+    }
+
+    const button = document.querySelector('[data-ai-id="auth-login-submit-button"]') as HTMLButtonElement | null;
+    button?.click();
+    return button ? 'buttonClick' : 'none';
+  });
+
+  const response = await responsePromise;
+  await page.waitForURL((url) => !url.toString().includes('/auth/login'), { timeout: 5_000 }).catch(() => null);
+
+  if (page.url().includes('/auth/login')) {
+    const pageError = await page.locator('.text-auth-error-center, [role="alert"]').first().textContent().catch(() => null);
+    if (pageError) {
+      throw new Error(`Login falhou para ${actor.email}: ${pageError}`);
+    }
+
+    await page.goto(`${baseUrl}/dashboard/overview`, { waitUntil: 'domcontentloaded', timeout: 60_000 }).catch((error: unknown) => {
+      const message = error instanceof Error ? error.message : String(error);
+      if (!message.includes('net::ERR_ABORTED')) {
+        throw error;
+      }
+    });
+    await page.waitForLoadState('domcontentloaded', { timeout: 30_000 }).catch(() => undefined);
+  }
+
+  if (page.url().includes('/auth/login')) {
+    const pageError = await page.locator('.text-auth-error-center, [role="alert"]').first().textContent().catch(() => null);
+    const formState = await page.evaluate(() => {
+      const email = (document.querySelector('[data-ai-id="auth-login-email-input"]') as HTMLInputElement | null)?.value;
+      const passwordLength = (document.querySelector('[data-ai-id="auth-login-password-input"]') as HTMLInputElement | null)?.value?.length ?? 0;
+      const submit = document.querySelector('[data-ai-id="auth-login-submit-button"]') as HTMLButtonElement | null;
+      return { email, passwordLength, submitDisabled: submit?.disabled ?? null };
+    }).catch(() => null);
+    throw new Error(`Login falhou para ${actor.email}${pageError ? `: ${pageError}` : ''}; submit=${submitted}; response=${response?.status() ?? 'none'}; form=${JSON.stringify(formState)}`);
+  }
+}
+
+export async function provisionPregaoFixture(prisma: PrismaClient, runId = createPregaoRunId()): Promise<PregaoFixture> {
+  const tenant = await prisma.tenant.findFirst({ where: { subdomain: 'demo' } }) ?? await prisma.tenant.findFirst();
+  if (!tenant) {
+    throw new Error('Nenhum tenant encontrado. Execute npm run db:seed antes do pregão filmado.');
+  }
+
+  const actors = buildPregaoActorMatrix(runId);
+  const allActors = [actors.auctionAgent, actors.admin, actors.auctioneer, actors.analyst, ...actors.buyers];
+  const roles = await ensureRoles(prisma, [...new Set(allActors.flatMap((actor) => actor.roles))]);
+  const createdUserIds: bigint[] = [];
+
+  for (const actor of allActors) {
+    const user = await ensureActorUser(prisma, tenant.id, actor, roles);
+    actor.userId = user.id;
+    createdUserIds.push(user.id);
+  }
+
+  const now = new Date();
+  const startDate = new Date(now.getTime() + 60_000);
+  const endDate = new Date(now.getTime() + 15 * 60_000);
+
+  const auction = await prisma.auction.create({
+    data: {
+      publicId: makePublicId(`auction-${runId}`),
+      slug: `pregao-multiperfil-${runId}`.slice(0, 180),
+      title: `Pregao Multi-Perfil Filmado ${runId}`,
+      description: 'Leilao de teste criado por agente dedicado para evidencia filmada multi-perfil.',
+      status: 'RASCUNHO',
+      auctionDate: startDate,
+      openDate: startDate,
+      endDate,
+      totalLots: 1,
+      totalHabilitatedUsers: PREGAO_BUYER_COUNT,
+      initialOffer: new Prisma.Decimal(PREGAO_INITIAL_PRICE),
+      createdByUserId: actors.auctionAgent.userId,
+      tenantId: tenant.id,
+      updatedAt: now,
+    },
+  });
+
+  const lot = await prisma.lot.create({
+    data: {
+      publicId: makePublicId(`lot-${runId}`),
+      number: '001',
+      title: `Lote Pregao Multi-Perfil ${runId}`,
+      description: 'Lote criado para disputa filmada com 10 compradores reais.',
+      status: 'RASCUNHO',
+      type: 'MOVENTE',
+      price: new Prisma.Decimal(PREGAO_INITIAL_PRICE),
+      initialPrice: new Prisma.Decimal(PREGAO_INITIAL_PRICE),
+      bidIncrementStep: new Prisma.Decimal(PREGAO_BID_INCREMENT),
+      endDate,
+      lotSpecificAuctionDate: startDate,
+      auctionId: auction.id,
+      tenantId: tenant.id,
+      updatedAt: now,
+    },
+  });
+
+  const stage = await prisma.auctionStage.create({
+    data: {
+      name: 'Praca Filmada Multi-Perfil',
+      startDate,
+      endDate,
+      status: 'ABERTO',
+      auctionId: auction.id,
+      tenantId: tenant.id,
+    },
+  });
+
+  await prisma.lotStagePrice.create({
+    data: {
+      lotId: lot.id,
+      auctionId: auction.id,
+      auctionStageId: stage.id,
+      initialBid: new Prisma.Decimal(PREGAO_INITIAL_PRICE),
+      bidIncrement: new Prisma.Decimal(PREGAO_BID_INCREMENT),
+      tenantId: tenant.id,
+    },
+  });
+
+  await enableBuyersForAuction(prisma, tenant.id, auction.id, actors.buyers);
+
+  return {
+    runId,
+    tenantId: tenant.id,
+    auctionId: auction.id,
+    auctionPublicId: auction.publicId ?? auction.id.toString(),
+    lotId: lot.id,
+    lotPublicId: lot.publicId ?? lot.id.toString(),
+    auctionStageId: stage.id,
+    actors,
+    bidSchedule: buildPregaoBidSchedule(actors.buyers, { runId }),
+    createdUserIds,
+  };
+}
+
+export async function runPregaoOpeningLifecycle(prisma: PrismaClient, fixture: PregaoFixture): Promise<void> {
+  const scheduledStart = new Date(Date.now() + 60_000);
+
+  await prisma.auction.update({
+    where: { id: fixture.auctionId },
+    data: {
+      auctionDate: scheduledStart,
+      openDate: scheduledStart,
+      endDate: new Date(Date.now() + 15 * 60_000),
+      updatedAt: new Date(),
+    },
+  });
+
+  const submit = await auctionStateMachine.submitForValidation({
+    auctionId: fixture.auctionId.toString(),
+    userId: requiredUserId(fixture.actors.auctionAgent).toString(),
+    tenantId: fixture.tenantId.toString(),
+  });
+  assertTransition(submit.success, submit.error, 'submeter leilao para validacao');
+
+  const approve = await auctionStateMachine.approveAuction(
+    {
+      auctionId: fixture.auctionId.toString(),
+      validatorUserId: requiredUserId(fixture.actors.admin).toString(),
+      tenantId: fixture.tenantId.toString(),
+      openDate: scheduledStart,
+    },
+    { id: requiredUserId(fixture.actors.admin), permissions: STATE_ADMIN_PERMISSIONS },
+  );
+  assertTransition(approve.success, approve.error, 'aprovar e agendar leilao');
+
+  const open = await auctionStateMachine.openAuction({
+    auctionId: fixture.auctionId.toString(),
+    userId: requiredUserId(fixture.actors.auctioneer).toString(),
+    tenantId: fixture.tenantId.toString(),
+    isAutomatic: false,
+  });
+  assertTransition(open.success, open.error, 'abrir leilao');
+
+  const startLot = await lotStateMachine.startLotAuction({
+    lotId: fixture.lotId.toString(),
+    auctionId: fixture.auctionId.toString(),
+    userId: requiredUserId(fixture.actors.auctioneer).toString(),
+    tenantId: fixture.tenantId.toString(),
+  });
+  assertTransition(startLot.success, startLot.error, 'iniciar lote em pregao');
+}
+
+export async function placePregaoBid(prisma: PrismaClient, fixture: PregaoFixture, entry: PregaoBidScheduleEntry): Promise<PregaoBidResult> {
+  const engine = new BidEngineV2();
+  const buyer = fixture.actors.buyers.find((candidate) => candidate.key === entry.buyerKey);
+  if (!buyer?.userId) {
+    throw new Error(`Comprador sem userId para lance: ${entry.buyerKey}`);
+  }
+
+  const result = await engine.placeBid(
+    {
+      lotId: fixture.lotId.toString(),
+      userId: buyer.userId.toString(),
+      amount: entry.amount,
+      bidderDisplay: buyer.label,
+      bidderAlias: buyer.bidderAlias,
+      bidOrigin: 'API',
+      clientIdempotencyKey: entry.idempotencyKey,
+      clientTimestamp: new Date().toISOString(),
+    },
+    { ipAddress: '127.0.0.1', userAgent: 'pregao-multiperfil-video' },
+    'CLIENT_UUID',
+  );
+
+  if (!result.success || !result.bidId || !result.currentBid) {
+    const lot = await prisma.lot.findUnique({ where: { id: fixture.lotId }, select: { price: true, bidsCount: true, status: true } });
+    throw new Error(`Falha ao registrar lance ${entry.buyerKey} R$${entry.amount}: ${result.message}. Lote=${JSON.stringify(lot)}`);
+  }
+
+  return {
+    ...entry,
+    bidId: result.bidId,
+    currentBid: result.currentBid,
+  };
+}
+
+export async function finalizePregaoWithWinner(prisma: PrismaClient, fixture: PregaoFixture): Promise<{
+  winnerUserId: bigint;
+  winnerBidderProfileId: bigint;
+  winningAmount: number;
+  userWinId: bigint;
+  reportId: bigint;
+}> {
+  const winningBid = await prisma.bid.findFirst({
+    where: { auctionId: fixture.auctionId, lotId: fixture.lotId, status: 'ATIVO' },
+    orderBy: [{ amount: 'desc' }, { timestamp: 'desc' }],
+  });
+
+  if (!winningBid) {
+    throw new Error('Nenhum lance ativo encontrado para finalizar o pregão.');
+  }
+
+  const winningAmount = Number(winningBid.amount);
+  const confirmSale = await lotStateMachine.confirmSale({
+    lotId: fixture.lotId.toString(),
+    auctionId: fixture.auctionId.toString(),
+    userId: requiredUserId(fixture.actors.auctioneer).toString(),
+    tenantId: fixture.tenantId.toString(),
+    winnerId: winningBid.bidderId.toString(),
+    soldPrice: winningAmount,
+  });
+  assertTransition(confirmSale.success, confirmSale.error, 'confirmar arrematacao');
+
+  const closeLot = await lotStateMachine.closeLot({
+    lotId: fixture.lotId.toString(),
+    auctionId: fixture.auctionId.toString(),
+    userId: requiredUserId(fixture.actors.auctioneer).toString(),
+    tenantId: fixture.tenantId.toString(),
+  });
+  assertTransition(closeLot.success, closeLot.error, 'fechar lote arrematado');
+
+  const closeAuction = await auctionStateMachine.closeAuction(
+    {
+      auctionId: fixture.auctionId.toString(),
+      userId: requiredUserId(fixture.actors.auctioneer).toString(),
+      tenantId: fixture.tenantId.toString(),
+    },
+    { id: requiredUserId(fixture.actors.auctioneer), permissions: STATE_AUCTIONEER_PERMISSIONS },
+  );
+  assertTransition(closeAuction.success, closeAuction.error, 'encerrar leilao');
+
+  const bidderProfile = await prisma.bidderProfile.findUnique({ where: { userId: winningBid.bidderId } });
+  if (!bidderProfile) {
+    throw new Error('Perfil de arrematante vencedor não encontrado.');
+  }
+
+  const userWin = await prisma.userWin.upsert({
+    where: { lotId: fixture.lotId },
+    update: {
+      userId: winningBid.bidderId,
+      winningBidAmount: new Prisma.Decimal(winningAmount),
+      paymentStatus: 'PENDENTE',
+      invoiceUrl: `/e2e/pregao/${fixture.runId}/invoice.pdf`,
+    },
+    create: {
+      lotId: fixture.lotId,
+      userId: winningBid.bidderId,
+      winningBidAmount: new Prisma.Decimal(winningAmount),
+      paymentStatus: 'PENDENTE',
+      invoiceUrl: `/e2e/pregao/${fixture.runId}/invoice.pdf`,
+      tenantId: fixture.tenantId,
+    },
+  });
+
+  await prisma.installmentPayment.upsert({
+    where: { userWinId_installmentNumber: { userWinId: userWin.id, installmentNumber: 1 } },
+    update: { status: 'PAGO', paymentDate: new Date(), paymentMethod: 'PIX_TESTE' },
+    create: {
+      userWinId: userWin.id,
+      installmentNumber: 1,
+      totalInstallments: 2,
+      amount: new Prisma.Decimal(winningAmount / 2),
+      dueDate: new Date(Date.now() + 24 * 60 * 60 * 1000),
+      paymentDate: new Date(),
+      status: 'PAGO',
+      paymentMethod: 'PIX_TESTE',
+      transactionId: `pregao-${fixture.runId}-1`,
+      tenantId: fixture.tenantId,
+    },
+  });
+
+  await prisma.installmentPayment.upsert({
+    where: { userWinId_installmentNumber: { userWinId: userWin.id, installmentNumber: 2 } },
+    update: { status: 'PENDENTE' },
+    create: {
+      userWinId: userWin.id,
+      installmentNumber: 2,
+      totalInstallments: 2,
+      amount: new Prisma.Decimal(winningAmount / 2),
+      dueDate: new Date(Date.now() + 7 * 24 * 60 * 60 * 1000),
+      status: 'PENDENTE',
+      tenantId: fixture.tenantId,
+    },
+  });
+
+  await prisma.wonLot.deleteMany({ where: { lotId: fixture.lotId, auctionId: fixture.auctionId } });
+  await prisma.wonLot.create({
+    data: {
+      bidderId: bidderProfile.id,
+      lotId: fixture.lotId,
+      auctionId: fixture.auctionId,
+      title: `Arrematacao Pregao ${fixture.runId}`,
+      finalBid: new Prisma.Decimal(winningAmount),
+      paymentStatus: 'PENDENTE',
+      totalAmount: new Prisma.Decimal(winningAmount),
+      paidAmount: new Prisma.Decimal(winningAmount / 2),
+      dueDate: new Date(Date.now() + 7 * 24 * 60 * 60 * 1000),
+      invoiceUrl: `/e2e/pregao/${fixture.runId}/invoice.pdf`,
+      receiptUrl: `/e2e/pregao/${fixture.runId}/receipt-partial.pdf`,
+      tenantId: fixture.tenantId,
+    },
+  });
+
+  const report = await prisma.report.create({
+    data: {
+      name: `Laudo Pregao Multi-Perfil ${fixture.runId}`,
+      description: 'Laudo e acompanhamento financeiro emitidos pelo analista para o vencedor do pregão filmado.',
+      definition: {
+        scenario: 'pregao-multiperfil-video',
+        auctionId: fixture.auctionId.toString(),
+        lotId: fixture.lotId.toString(),
+        winnerUserId: winningBid.bidderId.toString(),
+        winningAmount,
+        payment: { installments: 2, paidInstallments: 1 },
+      },
+      tenantId: fixture.tenantId,
+      createdById: requiredUserId(fixture.actors.analyst),
+    },
+  });
+
+  return {
+    winnerUserId: winningBid.bidderId,
+    winnerBidderProfileId: bidderProfile.id,
+    winningAmount,
+    userWinId: userWin.id,
+    reportId: report.id,
+  };
+}
+
+export async function teardownPregaoFixture(prisma: PrismaClient, fixture?: PregaoFixture): Promise<void> {
+  if (!fixture) {
+    return;
+  }
+
+  const generatedEmails = [
+    fixture.actors.auctionAgent.email,
+    fixture.actors.admin.email,
+    fixture.actors.auctioneer.email,
+    fixture.actors.analyst.email,
+    ...fixture.actors.buyers.map((buyer) => buyer.email),
+  ];
+
+  const userWin = await prisma.userWin.findUnique({ where: { lotId: fixture.lotId }, select: { id: true } }).catch(() => null);
+  if (userWin) {
+    await prisma.installmentPayment.deleteMany({ where: { userWinId: userWin.id } }).catch(() => undefined);
+  }
+
+  await prisma.report.deleteMany({ where: { name: { contains: fixture.runId } } }).catch(() => undefined);
+  await prisma.wonLot.deleteMany({ where: { auctionId: fixture.auctionId } }).catch(() => undefined);
+  await prisma.userWin.deleteMany({ where: { lotId: fixture.lotId } }).catch(() => undefined);
+  await prisma.bidIdempotencyLog.deleteMany({ where: { lotId: fixture.lotId } }).catch(() => undefined);
+  await prisma.bid.deleteMany({ where: { auctionId: fixture.auctionId } }).catch(() => undefined);
+  await prisma.auctionHabilitation.deleteMany({ where: { auctionId: fixture.auctionId } }).catch(() => undefined);
+  await prisma.lotStagePrice.deleteMany({ where: { auctionId: fixture.auctionId } }).catch(() => undefined);
+  await prisma.auctionStage.deleteMany({ where: { auctionId: fixture.auctionId } }).catch(() => undefined);
+  await prisma.lot.deleteMany({ where: { auctionId: fixture.auctionId } }).catch(() => undefined);
+  await prisma.auction.deleteMany({ where: { id: fixture.auctionId } }).catch(() => undefined);
+  await prisma.auditLog.deleteMany({ where: { userId: { in: fixture.createdUserIds } } }).catch(() => undefined);
+  await prisma.bidderProfile.deleteMany({ where: { userId: { in: fixture.createdUserIds } } }).catch(() => undefined);
+  await prisma.usersOnRoles.deleteMany({ where: { userId: { in: fixture.createdUserIds } } }).catch(() => undefined);
+
+  const userOnTenant = getUserOnTenantDelegate(prisma);
+  await userOnTenant.deleteMany({ where: { userId: { in: fixture.createdUserIds } } }).catch(() => undefined);
+  await prisma.user.deleteMany({ where: { email: { in: generatedEmails } } }).catch(() => undefined);
+}
+
+async function ensureRoles(prisma: PrismaClient, roleNames: string[]): Promise<Record<string, { id: bigint }>> {
+  const roles: Record<string, { id: bigint }> = {};
+  for (const roleName of roleNames) {
+    const role = await prisma.role.upsert({
+      where: { name: roleName },
+      update: { permissions: ROLE_PERMISSIONS[roleName] ?? [] },
+      create: {
+        name: roleName,
+        nameNormalized: roleName.toUpperCase(),
+        description: `Role ${roleName} para testes de pregão multi-perfil`,
+        permissions: ROLE_PERMISSIONS[roleName] ?? [],
+      },
+      select: { id: true },
+    });
+    roles[roleName] = role;
+  }
+  return roles;
+}
+
+async function ensureActorUser(
+  prisma: PrismaClient,
+  tenantId: bigint,
+  actor: PregaoActor | PregaoBuyerActor,
+  roles: Record<string, { id: bigint }>,
+): Promise<{ id: bigint }> {
+  const password = await bcryptjs.hash(actor.password, 10);
+  const user = await prisma.user.upsert({
+    where: { email: actor.email },
+    update: {
+      password,
+      fullName: actor.label,
+      habilitationStatus: 'HABILITADO',
+      accountType: 'PHYSICAL',
+      updatedAt: new Date(),
+    },
+    create: {
+      email: actor.email,
+      password,
+      fullName: actor.label,
+      habilitationStatus: 'HABILITADO',
+      accountType: 'PHYSICAL',
+      updatedAt: new Date(),
+    },
+    select: { id: true },
+  });
+
+  const userOnTenant = getUserOnTenantDelegate(prisma);
+  await userOnTenant.upsert({
+    where: { userId_tenantId: { userId: user.id, tenantId } },
+    update: { assignedBy: 'pregao-multiperfil-video' },
+    create: { userId: user.id, tenantId, assignedBy: 'pregao-multiperfil-video' },
+  });
+
+  for (const roleName of actor.roles) {
+    const role = roles[roleName];
+    if (!role) {
+      throw new Error(`Role ausente para ator ${actor.key}: ${roleName}`);
+    }
+    await prisma.usersOnRoles.upsert({
+      where: { userId_roleId: { userId: user.id, roleId: role.id } },
+      update: { assignedBy: 'pregao-multiperfil-video' },
+      create: { userId: user.id, roleId: role.id, assignedBy: 'pregao-multiperfil-video' },
+    });
+  }
+
+  if (actor.kind === 'buyer') {
+    const bidderProfile = await prisma.bidderProfile.upsert({
+      where: { userId: user.id },
+      update: {
+        fullName: actor.label,
+        documentStatus: 'APPROVED',
+        isActive: true,
+        tenantId,
+      },
+      create: {
+        userId: user.id,
+        fullName: actor.label,
+        documentStatus: 'APPROVED',
+        isActive: true,
+        tenantId,
+      },
+      select: { id: true },
+    });
+    (actor as PregaoBuyerActor).bidderProfileId = bidderProfile.id;
+  }
+
+  return user;
+}
+
+async function enableBuyersForAuction(
+  prisma: PrismaClient,
+  tenantId: bigint,
+  auctionId: bigint,
+  buyers: PregaoBuyerActor[],
+): Promise<void> {
+  for (const buyer of buyers) {
+    await prisma.auctionHabilitation.upsert({
+      where: { userId_auctionId: { userId: requiredUserId(buyer), auctionId } },
+      update: { tenantId, habilitatedAt: new Date() },
+      create: { userId: requiredUserId(buyer), auctionId, tenantId },
+    });
+  }
+}
+
+function requiredUserId(actor: PregaoActor): bigint {
+  if (!actor.userId) {
+    throw new Error(`Ator sem userId: ${actor.key}`);
+  }
+  return actor.userId;
+}
+
+function assertTransition(success: boolean, error: string | undefined, label: string): void {
+  expect(success, `Falha ao ${label}: ${error ?? 'sem detalhes'}`).toBe(true);
+}
+
+function makePublicId(seed: string): string {
+  return createHash('sha256').update(`${seed}-${Date.now()}-${randomUUID()}`).digest('hex').slice(0, 16);
+}
+
+function makeIdempotencyKey(runId: string, round: number, buyerKey: string, amount: number): string {
+  return createHash('sha256').update(`${runId}:${round}:${buyerKey}:${amount}`).digest('hex').slice(0, 64);
+}
+
+function getUserOnTenantDelegate(prisma: PrismaClient): any {
+  return (prisma as any).userOnTenant ?? (prisma as any).usersOnTenants;
+}
+
+export async function seedPregaoActorSession(
+  context: BrowserContext,
+  actor: PregaoActor,
+  baseUrl: string,
+  tenantId: bigint,
+): Promise<void> {
+  const userId = requiredUserId(actor);
+  const secret = resolveSessionSecret(baseUrl);
+  const expiresAt = Math.floor(Date.now() / 1000) + 7 * 24 * 60 * 60;
+  const permissions = [...new Set(actor.roles.flatMap((role) => ROLE_PERMISSIONS[role] ?? []))];
+  const token = await new SignJWT({
+    userId: userId.toString(),
+    email: actor.email,
+    tenantId: tenantId.toString(),
+    roleNames: actor.roles,
+    permissions,
+    sellerId: null,
+    auctioneerId: null,
+  })
+    .setProtectedHeader({ alg: 'HS256' })
+    .setIssuedAt()
+    .setExpirationTime('7d')
+    .sign(new TextEncoder().encode(secret));
+
+  const host = new URL(baseUrl).hostname;
+  await context.addCookies([
+    {
+      name: 'session',
+      value: token,
+      domain: host,
+      path: '/',
+      expires: expiresAt,
+      httpOnly: true,
+      secure: false,
+      sameSite: 'Lax',
+    },
+    {
+      name: 'magic_cookie_test',
+      value: 'test_from_playwright',
+      domain: host,
+      path: '/',
+      expires: expiresAt,
+      httpOnly: false,
+      secure: false,
+      sameSite: 'Lax',
+    },
+  ]);
+}
+
+function resolveSessionSecret(baseUrl: string): string {
+  const secret = process.env.SESSION_SECRET || process.env.AUTH_SECRET || process.env.NEXTAUTH_SECRET;
+  if (secret && secret.length >= 32) {
+    return secret;
+  }
+
+  const port = new URL(baseUrl).port || process.env.PORT || '9028';
+  return `bidexpert_local_session_secret_${port}_len_40`;
+}

--- a/tests/e2e/pregao-disputas-video.spec.ts
+++ b/tests/e2e/pregao-disputas-video.spec.ts
@@ -1,630 +1,272 @@
 /**
- * pregao-disputas-video.spec.ts
- * Simulação E2E de Pregão com 1 admin (monitor) + 10 robôs arrematantes.
- *
- * BDD:
- *   Feature: Captura em Vídeo da Disputa de Lances no Pregão BidExpert
- *
- *     Como equipe de QA
- *     Quero simular 10 robôs competindo num pregão de 5 minutos
- *     Para produzir evidência visual (vídeo) da disputa de lances em tempo real
- *
- * Fluxo:
- *   1. Setup de dados (tenant, leilão, 10 robôs) via Prisma
- *   2. Admin abre o Monitor de Pregão (vídeo gravado)
- *   3. 10 robôs fazem lances sequenciais no DB (simula disputa rápida)
- *   4. Monitor exibe atualizações a cada polling (3 s)
- *   5. Robôs também interagem via UI (contextos separados, cada um com vídeo)
- *   6. Leilão encerrado; vencedor identificado
- *   7. Teardown: dados de teste removidos
- *
- * Artefatos gerados:
- *   - test-results/pregao-video/artifacts/        (screenshots + vídeos)
- *   - test-results/pregao-video/report/           (HTML report)
- *   - test-results/pregao-video/results.json
+ * @fileoverview Jornada E2E filmada do pregão multi-perfil.
+ * Usa atores Playwright separados, BidEngineV2 para lances e máquina de estado
+ * para abertura, arrematação e encerramento.
  */
 
-import {
-  test,
-  expect,
-  type Browser,
-  type BrowserContext,
-  type Page,
-} from '@playwright/test';
+import { test, expect, type Browser, type BrowserContext, type Page } from '@playwright/test';
 import { PrismaClient } from '@prisma/client';
-import * as fs from 'node:fs';
-import * as path from 'node:path';
-import * as crypto from 'node:crypto';
-import { CREDENTIALS as AUTH_CREDENTIALS } from './helpers/auth-helper';
+import fs from 'node:fs';
+import path from 'node:path';
 
-// ─── Configuração Central ─────────────────────────────────────────────────────
+import { ensureSeedExecuted } from './helpers/auth-helper';
+import {
+  PREGAO_BUYER_COUNT,
+  PREGAO_INITIAL_PRICE,
+  finalizePregaoWithWinner,
+  groupPregaoScheduleByRound,
+  parseBrazilianCurrency,
+  placePregaoBid,
+  provisionPregaoFixture,
+  resolvePregaoWinner,
+  runPregaoOpeningLifecycle,
+  seedPregaoActorSession,
+  teardownPregaoFixture,
+  type PregaoActor,
+  type PregaoBidResult,
+  type PregaoFixture,
+} from './helpers/pregao-multiperfil-fixture';
 
 const BASE_URL = process.env.PREGAO_BASE_URL || 'http://demo.localhost:9005';
-const LOGIN_URL = `${BASE_URL}/auth/login`;
+const ARTIFACT_ROOT = 'test-results/pregao-video';
+const SCREENSHOT_DIR = path.join(ARTIFACT_ROOT, 'screenshots');
+const VIDEO_DIR = path.join(ARTIFACT_ROOT, 'artifacts');
+const VIEWPORT = { width: 1280, height: 720 } as const;
 
-/**
- * Credenciais do admin (devem existir no seed).
- * Usuário: admin@lordland.com / password123
- */
-const ADMIN_CREDENTIALS = {
-  email: AUTH_CREDENTIALS.admin.email,
-  password: AUTH_CREDENTIALS.admin.password,
-};
+let prisma: PrismaClient;
+let fixture: PregaoFixture | undefined;
 
-const LOGIN_CANDIDATES = [
-  { email: AUTH_CREDENTIALS.admin.email, password: AUTH_CREDENTIALS.admin.password },
-  ADMIN_CREDENTIALS,
-  { email: AUTH_CREDENTIALS.leiloeiro.email, password: AUTH_CREDENTIALS.leiloeiro.password },
-  { email: AUTH_CREDENTIALS.comprador.email, password: AUTH_CREDENTIALS.comprador.password },
-];
+test.describe.serial('Pregão multi-perfil filmado', () => {
+  test.setTimeout(20 * 60 * 1000);
 
-/** Senha padrão para todos os robôs de teste. */
-const BOT_PASSWORD = 'RoboLance@2025';
-
-/** Número de robôs que disputam o leilão. */
-const BOT_COUNT = 10;
-
-/** Valor inicial do lote (R$). */
-const INITIAL_PRICE = 5_000;
-
-/** Incremento por lance (R$). */
-const BID_INCREMENT = 500;
-
-/** Número de rodadas de lances (cada robô lance 1x por rodada = 10 lances/rodada). */
-const BID_ROUNDS = 9; // ~90 lances totais; com polling 3 s o monitor atualiza ~30 vezes
-
-/** Intervalo entre rodadas de lances (ms). Mantém o vídeo interessante sem ser longo demais. */
-const ROUND_INTERVAL_MS = 3_000;
-
-/** Diretório de screenshots manuais. */
-const SCREENSHOT_DIR = 'test-results/pregao-video/screenshots';
-
-// ─── Utilitários ──────────────────────────────────────────────────────────────
-
-function ensureDirs(): void {
-  [SCREENSHOT_DIR, 'test-results/pregao-video/artifacts'].forEach((d) => {
-    if (!fs.existsSync(d)) fs.mkdirSync(d, { recursive: true });
-  });
-}
-
-async function captureStep(page: Page, label: string): Promise<void> {
-  const filename = `${Date.now()}-${label.replace(/[^a-z0-9]/gi, '_')}.png`;
-  await page.screenshot({
-    path: path.join(SCREENSHOT_DIR, filename),
-    fullPage: false,
-  });
-}
-
-function generateBotEmail(index: number, runId: string): string {
-  return `robo.lance.${runId}.${index}@lordland.test`;
-}
-
-/** Hash SHA-256 simples para gerar publicId único sem bcrypt. */
-function makePublicId(seed: string): string {
-  return crypto.createHash('sha256').update(seed + Date.now()).digest('hex').slice(0, 16);
-}
-
-// ─── Login helper ────────────────────────────────────────────────────────────
-
-async function doLogin(page: Page, email: string, password: string): Promise<void> {
-  let lastNavigationError: unknown = null;
-  for (let attempt = 1; attempt <= 4; attempt++) {
-    try {
-      await page.goto(LOGIN_URL, { waitUntil: 'domcontentloaded', timeout: 60_000 });
-      lastNavigationError = null;
-      break;
-    } catch (error) {
-      lastNavigationError = error;
-      const message = error instanceof Error ? error.message : String(error);
-      const isTransientConnectionError =
-        message.includes('ERR_CONNECTION_REFUSED') ||
-        message.includes('ERR_CONNECTION_RESET') ||
-        message.includes('ERR_CONNECTION_CLOSED');
-
-      if (!isTransientConnectionError || attempt === 4) {
-        throw error;
-      }
-
-      await page.waitForTimeout(1500 * attempt);
-    }
-  }
-
-  if (lastNavigationError) {
-    throw lastNavigationError;
-  }
-
-  if (!page.url().includes('/auth/login')) {
-    return;
-  }
-
-  const devAutoLoginTrigger = page.getByText('Selecione para auto-login...', { exact: false }).first();
-  if (await devAutoLoginTrigger.isVisible({ timeout: 5_000 }).catch(() => false)) {
-    await devAutoLoginTrigger.click();
-    const preferredAutoLoginOption = page.getByRole('option', { name: new RegExp(email, 'i') }).first();
-    const firstAutoLoginOption = page.locator('[role="option"]').first();
-
-    if (await preferredAutoLoginOption.isVisible({ timeout: 2_000 }).catch(() => false)) {
-      await preferredAutoLoginOption.click();
-    } else if (await firstAutoLoginOption.isVisible({ timeout: 8_000 }).catch(() => false)) {
-      await firstAutoLoginOption.click();
-    }
-
-    await page.waitForURL((u) => !u.toString().includes('/auth/login'), { timeout: 40_000 }).catch(() => null);
-    if (!page.url().includes('/auth/login')) {
-      return;
-    }
-
-    await page.keyboard.press('Escape').catch(() => null);
-  }
-
-  await page.keyboard.press('Escape').catch(() => null);
-
-  const tenantTrigger = page.locator('[data-ai-id="auth-login-tenant-select"]').first();
-  const tenantVisible = await tenantTrigger.isVisible({ timeout: 5_000 }).catch(() => false);
-  if (tenantVisible) {
-    const tenantReady = await expect
-      .poll(async () => {
-        const isDisabled = await tenantTrigger.isDisabled().catch(() => false);
-        const triggerText = ((await tenantTrigger.textContent().catch(() => '')) || '').toLowerCase();
-        const hasValue = !/selecione|carregando/i.test(triggerText);
-
-        if (/carregando/i.test(triggerText)) return false;
-
-        if (isDisabled) {
-          return hasValue;
-        }
-
-        return true;
-      }, {
-        timeout: 60_000,
-        intervals: [500, 1000, 1500, 2000],
-      })
-      .toBeTruthy()
-      .then(() => true)
-      .catch(() => false);
-
-    if (!tenantReady) {
-      throw new Error('Tenant não ficou pronto para login (subdomínio ainda não resolvido).');
-    }
-
-    await page.waitForTimeout(300);
-  }
-
-  const emailInput = page.locator(
-    '[data-ai-id="auth-login-email-input"], input[type="email"], input[name="email"], input[placeholder*="email" i]'
-  ).first();
-  const passInput = page.locator(
-    '[data-ai-id="auth-login-password-input"], input[type="password"], input[name="password"]'
-  ).first();
-
-  const hasEmailInput = await emailInput.isVisible({ timeout: 2_000 }).catch(() => false);
-  const hasPasswordInput = await passInput.isVisible({ timeout: 2_000 }).catch(() => false);
-
-  if (hasEmailInput && hasPasswordInput) {
-    await emailInput.fill(email);
-    await passInput.fill(password);
-
-    await Promise.all([
-      page.waitForURL((u) => !u.toString().includes('/auth/login'), { timeout: 30_000 }).catch(() => null),
-      page.locator(
-        '[data-ai-id="auth-login-submit-button"], button[type="submit"], button:has-text("Entrar"), button:has-text("Login")'
-      ).first().click(),
-    ]);
-    return;
-  }
-
-  const submitButton = page.locator(
-    '[data-ai-id="auth-login-submit-button"], button[type="submit"], button:has-text("Entrar"), button:has-text("Login")'
-  ).first();
-
-  if (await submitButton.isVisible({ timeout: 3_000 }).catch(() => false)) {
-    await Promise.all([
-      page.waitForURL((u) => !u.toString().includes('/auth/login'), { timeout: 30_000 }).catch(() => null),
-      submitButton.click(),
-    ]);
-    return;
-  }
-
-  throw new Error('UI de login em estado não suportado (sem campos e sem botão de submit).');
-}
-
-async function loginWithFallback(page: Page): Promise<void> {
-  if (page.isClosed()) {
-    throw new Error('Página foi fechada antes do login.');
-  }
-
-  let lastErrorMessage = 'sem detalhes';
-  for (const candidate of LOGIN_CANDIDATES) {
-    await doLogin(page, candidate.email, candidate.password);
-
-    if (!page.url().includes('/auth/login')) {
-      return;
-    }
-
-    const authErrorText = await page
-      .locator('.text-auth-error, [role="alert"]')
-      .first()
-      .innerText()
-      .catch(() => 'sem mensagem de erro visível');
-
-    const tenantState = await page
-      .locator('[data-ai-id="auth-login-tenant-select"]')
-      .first()
-      .textContent()
-      .catch(() => 'tenant-select indisponível');
-
-    lastErrorMessage = `email=${candidate.email} authError="${authErrorText}" tenantState="${tenantState}"`;
-  }
-
-  throw new Error(`Nenhuma estratégia de login funcionou: ${lastErrorMessage}`);
-}
-
-// ─── Setup/Teardown de Dados via Prisma ──────────────────────────────────────
-
-interface TestFixture {
-  prisma: PrismaClient;
-  tenantId: bigint;
-  auctionId: bigint;
-  auctionPublicId: string;
-  lotId: bigint;
-  lotPublicId: string;
-  botUserIds: bigint[];
-  botEmails: string[];
-  runId: string;
-}
-
-let fixture: TestFixture;
-
-async function setupTestData(): Promise<TestFixture> {
-  const prisma = new PrismaClient();
-  const runId = Date.now().toString(36);
-
-  // Descobrir tenant existente (subdomain "demo" ou primeiro disponível)
-  let tenant = await prisma.tenant.findFirst({ where: { subdomain: 'demo' } });
-  if (!tenant) {
-    tenant = await prisma.tenant.findFirst();
-  }
-  if (!tenant) {
-    throw new Error('Nenhum tenant encontrado no banco de dados. Execute o seed antes dos testes.');
-  }
-
-  // Criar leilão de teste com duração de 5 minutos
-  const endDate = new Date(Date.now() + 5 * 60 * 1000);
-
-  const auction = await prisma.auction.create({
-    data: {
-      publicId: makePublicId(`auction-${runId}`),
-      title: `Pregao Robotico ${runId} - Disputa de Lances`,
-      description: 'Leilão automatizado para captura de vídeo de disputas.',
-      status: 'ABERTO_PARA_LANCES',
-      auctionDate: new Date(),
-      endDate,
-      tenantId: tenant.id,
-      updatedAt: new Date(),
-    },
-  });
-
-  // Criar lote de teste
-  const lot = await prisma.lot.create({
-    data: {
-      publicId: makePublicId(`lot-${runId}`),
-      title: `Lote Robotico ${runId} - iPhone 15 Pro Max`,
-      description: 'Lote criado automaticamente para simulação de disputa de lances.',
-      number: '001',
-      status: 'ABERTO_PARA_LANCES',
-      type: 'MOVENTE',
-      price: INITIAL_PRICE,
-      initialPrice: INITIAL_PRICE,
-      auctionId: auction.id,
-      tenantId: tenant.id,
-      updatedAt: new Date(),
-    },
-  });
-
-  // Criar 10 robôs
-  const botUserIds: bigint[] = [];
-  const botEmails: string[] = [];
-
-  for (let i = 1; i <= BOT_COUNT; i++) {
-    const email = generateBotEmail(i, runId);
-    botEmails.push(email);
-
-    // Robôs não precisam de senha real; o login via UI usa a senha padrão
-    // Para o teste, inserimos bids diretamente via Prisma (sem necessidade de login dos robôs)
-    const user = await prisma.user.upsert({
-      where: { email },
-      update: { updatedAt: new Date() },
-      create: {
-        email,
-        fullName: `Robo Arrematante ${i}`,
-        updatedAt: new Date(),
-      },
-    });
-
-    botUserIds.push(user.id);
-  }
-
-  return {
-    prisma,
-    tenantId: tenant.id,
-    auctionId: auction.id,
-    auctionPublicId: auction.publicId ?? auction.id.toString(),
-    lotId: lot.id,
-    lotPublicId: lot.publicId ?? lot.id.toString(),
-    botUserIds,
-    botEmails,
-    runId,
-  };
-}
-
-async function teardownTestData(f: TestFixture): Promise<void> {
-  const { prisma, auctionId, botUserIds, botEmails } = f;
-
-  // Remove bids do lote de teste
-  await prisma.bid.deleteMany({ where: { auctionId } });
-
-  // Remove lotes
-  await prisma.lot.deleteMany({ where: { auctionId } });
-
-  // Remove o leilão
-  await prisma.auction.delete({ where: { id: auctionId } }).catch(() => null);
-
-  // Remove os robôs
-  for (const email of botEmails) {
-    await prisma.user.delete({ where: { email } }).catch(() => null);
-  }
-
-  await prisma.$disconnect();
-}
-
-// ─── Simulação de Lances (via Prisma) ────────────────────────────────────────
-
-/**
- * Insere um lance diretamente no banco, simulando o arrematante `botIndex`.
- * O monitor irá buscar este lance no próximo polling (3 s).
- */
-async function insertRobotBid(
-  prisma: PrismaClient,
-  f: TestFixture,
-  botIndex: number,
-  amount: number
-): Promise<void> {
-  const bidderId = f.botUserIds[botIndex];
-
-  await prisma.bid.create({
-    data: {
-      lotId: f.lotId,
-      auctionId: f.auctionId,
-      bidderId,
-      amount,
-      status: 'ATIVO',
-      isAutoBid: true,
-      tenantId: f.tenantId,
-      timestamp: new Date(),
-    },
-  });
-
-  // Atualiza o preço atual do lote
-  await prisma.lot.update({
-    where: { id: f.lotId },
-    data: {
-      price: amount,
-      bidsCount: { increment: 1 },
-      updatedAt: new Date(),
-    },
-  });
-}
-
-// ─── Abertura do Contexto de Admin (com vídeo) ────────────────────────────────
-
-async function openAdminMonitorContext(
-  browser: Browser,
-  f: TestFixture
-): Promise<{ context: BrowserContext; page: Page }> {
-  const context = await browser.newContext({
-    recordVideo: {
-      dir: 'test-results/pregao-video/artifacts',
-      size: { width: 1280, height: 720 },
-    },
-    viewport: { width: 1280, height: 720 },
-  });
-
-  let page = await context.newPage();
-  const monitorUrl = `${BASE_URL}/auctions/${f.auctionPublicId}/monitor`;
-
-  await page.goto(monitorUrl, { waitUntil: 'domcontentloaded', timeout: 60_000 });
-  if (!page.url().includes('/auth/login')) {
-    return { context, page };
-  }
-
-  // Faz login com fallback para novo fluxo de tenant/subdomínio
-  try {
-    await loginWithFallback(page);
-  } catch (error) {
-    if (!page.isClosed()) {
-      throw error;
-    }
-    page = await context.newPage();
-    await loginWithFallback(page);
-  }
-
-  await page.goto(monitorUrl, { waitUntil: 'domcontentloaded', timeout: 60_000 });
-
-  return { context, page };
-}
-
-// ─── Suíte Principal ──────────────────────────────────────────────────────────
-
-test.describe.serial('🎬 Pregão BidExpert - Disputas em Vídeo', () => {
-  test.setTimeout(10 * 60 * 1000); // 10 minutos total
-
-  // ── Setup global ────────────────────────────────────────────────────────────
   test.beforeAll(async () => {
     ensureDirs();
-    fixture = await setupTestData();
+    await ensureSeedExecuted(BASE_URL);
+    prisma = new PrismaClient();
+    fixture = await provisionPregaoFixture(prisma);
   });
 
   test.afterAll(async () => {
-    if (fixture) {
-      await teardownTestData(fixture);
-    }
+    await teardownPregaoFixture(prisma, fixture);
+    await prisma?.$disconnect();
   });
 
-  // ──────────────────────────────────────────────────────────────────────────
-  // TESTE 1: Admin abre o Monitor e Robôs disputam lances
-  // ──────────────────────────────────────────────────────────────────────────
-  test('Disputa de lances: 10 robôs × 9 rodadas com monitor em tempo real', async ({ browser }) => {
-    // 1. Admin abre o monitor (vídeo começa aqui)
-    const { context: adminCtx, page: adminPage } = await openAdminMonitorContext(browser, fixture);
+  test('filma criação, habilitação, disputa, arrematação e laudo com atores separados', async ({ browser }, testInfo) => {
+    const f = requiredFixture();
+    const contexts: BrowserContext[] = [];
+    const bidResults: PregaoBidResult[] = [];
+    const monitorUrl = `${BASE_URL}/auctions/${f.auctionPublicId}/monitor`;
 
     try {
-      // Espera o monitor carregar
-      const monitorEl = adminPage.locator('[data-ai-id="monitor-auditorium"]');
-      const monitorLoaded = await monitorEl.isVisible({ timeout: 20_000 }).catch(() => false);
+      const camera = await openRecordedActor(browser, 'camera-monitor');
+      contexts.push(camera.context);
+      await camera.page.goto(monitorUrl, { waitUntil: 'domcontentloaded', timeout: 120_000 });
+      await expect(camera.page.locator('[data-ai-id="monitor-auditorium"]')).toBeVisible({ timeout: 60_000 });
+      await captureStep(camera.page, '00-camera-monitor-criado');
 
-      if (!monitorLoaded) {
-        // Se não houver monitor (seed não tem leilão aberto), apenas verifica a página
-        console.log('Monitor não encontrado — verificando estado da página...');
-        await captureStep(adminPage, 'admin-page-state');
-        // A estrutura do teste permanece válida; o vídeo captura o que existe
-      } else {
-        await captureStep(adminPage, '01-monitor-aberto');
-        console.log(`✅ Monitor aberto para leilão ${fixture.auctionPublicId}`);
+      const auctionAgent = await openLoggedActor(browser, f.actors.auctionAgent, monitorUrl, contexts, f.tenantId);
+      await captureStep(auctionAgent, '01-agente-criou-leilao-lote');
+
+      const admin = await openAdminActor(browser, contexts, f, monitorUrl);
+      await captureStep(admin, '02-admin-habilitou-compradores');
+
+      const auctioneer = await openLoggedActor(browser, f.actors.auctioneer, monitorUrl, contexts, f.tenantId);
+      await runPregaoOpeningLifecycle(prisma, f);
+      await camera.page.reload({ waitUntil: 'domcontentloaded', timeout: 120_000 });
+      await expect(camera.page.locator('[data-ai-id="monitor-auditorium"]')).toBeVisible({ timeout: 60_000 });
+      await captureStep(auctioneer, '03-leiloeiro-abriu-pregao');
+      await captureStep(camera.page, '04-camera-pregao-aberto');
+
+      const buyerPages: Page[] = [];
+      for (const buyer of f.actors.buyers) {
+        const buyerPage = await openLoggedActor(browser, buyer, monitorUrl, contexts, f.tenantId);
+        buyerPages.push(buyerPage);
       }
 
-      // 2. Simula as rodadas de disputa
-      let currentBid = INITIAL_PRICE;
-      const bidLog: Array<{ round: number; bot: number; amount: number }> = [];
+      await captureStep(buyerPages[0], '05-comprador-01-pronto');
+      await captureStep(buyerPages[buyerPages.length - 1], '06-comprador-10-pronto');
+      await assertBuyerRoleIsolation(f);
+      await assertBuyerHabilitations(f);
 
-      for (let round = 1; round <= BID_ROUNDS; round++) {
-        console.log(`\n📢 Rodada ${round}/${BID_ROUNDS} de lances...`);
-
-        // Cada robô dá 1 lance por rodada (lances sequenciais)
-        for (let botIdx = 0; botIdx < BOT_COUNT; botIdx++) {
-          currentBid += BID_INCREMENT;
-          await insertRobotBid(fixture.prisma, fixture, botIdx, currentBid);
-
-          bidLog.push({ round, bot: botIdx + 1, amount: currentBid });
-          console.log(`   Robô ${botIdx + 1} → R$ ${currentBid.toLocaleString('pt-BR')}`);
+      const groupedRounds = groupPregaoScheduleByRound(f.bidSchedule);
+      for (const roundEntries of groupedRounds) {
+        for (const entry of roundEntries) {
+          bidResults.push(await placePregaoBid(prisma, f, entry));
         }
 
-        // Pausa para o polling do monitor capturar os novos lances
-        await adminPage.waitForTimeout(ROUND_INTERVAL_MS);
+        const roundLastBid = roundEntries[roundEntries.length - 1];
+        await expect.poll(async () => {
+          const lot = await prisma.lot.findUnique({ where: { id: f.lotId }, select: { price: true, bidsCount: true } });
+          return { price: Number(lot?.price ?? 0), bidsCount: lot?.bidsCount ?? 0 };
+        }, {
+          timeout: 30_000,
+          intervals: [500, 1_000, 2_000],
+        }).toEqual({ price: roundLastBid.amount, bidsCount: bidResults.length });
 
-        // Screenshot da rodada para o relatório
-        await captureStep(adminPage, `rodada-${round.toString().padStart(2, '0')}`);
+        await camera.page.reload({ waitUntil: 'domcontentloaded', timeout: 120_000 });
+        await expect(camera.page.locator('[data-ai-id="monitor-current-amount"]')).toBeVisible({ timeout: 60_000 });
+        await expect.poll(async () => {
+          const amountText = await camera.page.locator('[data-ai-id="monitor-current-amount"]').textContent().catch(() => '');
+          return parseBrazilianCurrency(amountText);
+        }, {
+          timeout: 30_000,
+          intervals: [1_000, 2_000, 3_000],
+        }).toBeGreaterThanOrEqual(roundLastBid.amount);
+        await expectVisibleBidCount(camera.page, bidResults.length);
+        await captureStep(camera.page, `07-camera-rodada-${roundLastBid.round}`);
       }
 
-      // 3. Screenshot final antes de encerrar
-      await captureStep(adminPage, 'final-disputa');
+      const expectedWinner = resolvePregaoWinner(f.bidSchedule);
+      const finalization = await finalizePregaoWithWinner(prisma, f);
+      expect(finalization.winningAmount).toBe(expectedWinner.amount);
 
-      // 4. Validações básicas de UI (se o monitor estiver visível)
-      if (monitorLoaded) {
-        // O monitor deve continuar visível após todas as rodadas
-        await expect(monitorEl).toBeVisible({ timeout: 10_000 });
+      await camera.page.reload({ waitUntil: 'domcontentloaded', timeout: 120_000 });
+      await expect(camera.page.locator('[data-ai-id="monitor-auditorium"]')).toBeVisible({ timeout: 60_000 });
+      await expectVisibleBidCount(camera.page, bidResults.length);
+      await captureStep(camera.page, '08-camera-vencedor-confirmado');
 
-        // Verifica que há alguma informação de lance no display
-        const bidDisplay = adminPage.locator('[data-ai-id="monitor-bid-display"]');
-        const displayVisible = await bidDisplay.isVisible().catch(() => false);
-        if (displayVisible) {
-          await expect(bidDisplay).toBeVisible();
-        }
-      }
+      const analyst = await openLoggedActor(browser, f.actors.analyst, monitorUrl, contexts, f.tenantId);
+      await captureStep(analyst, '09-analista-laudo-cobranca');
+      await assertWinnerOnlyArtifacts(f, finalization.winnerUserId, finalization.reportId);
 
-      // 5. Salva log de lances como JSON
-      const logPath = 'test-results/pregao-video/bid-log.json';
-      fs.writeFileSync(
-        logPath,
-        JSON.stringify(
-          {
-            runId: fixture.runId,
-            auctionId: fixture.auctionPublicId,
-            lotId: fixture.lotPublicId,
-            totalBids: bidLog.length,
-            finalAmount: currentBid,
-            rounds: BID_ROUNDS,
-            bots: BOT_COUNT,
-            timestamp: new Date().toISOString(),
-            bids: bidLog,
-          },
-          null,
-          2
-        )
-      );
-      console.log(`\n✅ Log de lances salvo em: ${logPath}`);
-      console.log(`✅ Total de lances: ${bidLog.length}`);
-      console.log(`✅ Lance final: R$ ${currentBid.toLocaleString('pt-BR')}`);
+      const bidLog = {
+        runId: f.runId,
+        baseUrl: BASE_URL,
+        auctionId: f.auctionId.toString(),
+        lotId: f.lotId.toString(),
+        buyerCount: PREGAO_BUYER_COUNT,
+        initialPrice: PREGAO_INITIAL_PRICE,
+        totalBids: bidResults.length,
+        expectedWinner,
+        finalization: {
+          winnerUserId: finalization.winnerUserId.toString(),
+          winningAmount: finalization.winningAmount,
+          userWinId: finalization.userWinId.toString(),
+          reportId: finalization.reportId.toString(),
+        },
+        bids: bidResults,
+      };
 
-    } finally {
-      // Garante que o vídeo é salvo mesmo em caso de falha
-      await captureStep(adminPage, 'teardown-monitor');
-      await adminCtx.close();
-    }
-  });
-
-  // ──────────────────────────────────────────────────────────────────────────
-  // TESTE 2: Verificação pós-disputa — lances registrados no banco
-  // ──────────────────────────────────────────────────────────────────────────
-  test('Verifica lances registrados no banco após a disputa', async () => {
-    const prisma = fixture.prisma;
-
-    const bids = await prisma.bid.findMany({
-      where: { auctionId: fixture.auctionId, lotId: fixture.lotId },
-      orderBy: { timestamp: 'asc' },
-    });
-
-    const expectedBids = BOT_COUNT * BID_ROUNDS;
-
-    console.log(`\n📊 Lances registrados no banco: ${bids.length} (esperado: ${expectedBids})`);
-
-    // Deve haver pelo menos 1 lance (tolerante a falhas parciais)
-    expect(bids.length).toBeGreaterThan(0);
-
-    // O lance mais alto deve ser o da última rodada
-    const maxAmount = Math.max(...bids.map((b) => Number(b.amount)));
-    const expectedMax = INITIAL_PRICE + BID_INCREMENT * BOT_COUNT * BID_ROUNDS;
-    console.log(`📊 Lance mais alto: R$ ${maxAmount.toLocaleString('pt-BR')} (esperado: R$ ${expectedMax.toLocaleString('pt-BR')})`);
-
-    expect(maxAmount).toBeGreaterThanOrEqual(INITIAL_PRICE + BID_INCREMENT);
-
-    // Todos os robôs devem ter pelo menos 1 lance
-    const bidderIds = new Set(bids.map((b) => b.bidderId));
-    console.log(`📊 Robôs que deram lance: ${bidderIds.size}/${BOT_COUNT}`);
-    expect(bidderIds.size).toBeGreaterThan(0);
-  });
-
-  // ──────────────────────────────────────────────────────────────────────────
-  // TESTE 3: Monitor acessível após a disputa (smoke check)
-  // ──────────────────────────────────────────────────────────────────────────
-  test('Monitor continua acessível após a disputa', async ({ page }) => {
-    const monitorUrl = `${BASE_URL}/auctions/${fixture.auctionPublicId}/monitor`;
-    await page.goto(monitorUrl, { waitUntil: 'domcontentloaded', timeout: 60_000 });
-
-    if (page.url().includes('/auth/login')) {
-      await loginWithFallback(page);
-      await page.goto(monitorUrl, { waitUntil: 'domcontentloaded', timeout: 60_000 });
-    }
-
-    // Captura estado final da página
-    await captureStep(page, 'pos-disputa-monitor');
-
-    // A página deve carregar sem redirecionar para login
-    expect(page.url()).toContain(`/auctions/${fixture.auctionPublicId}/monitor`);
-
-    await expect.poll(async () => {
-      return await page.evaluate(() => {
-        const body = document.body;
-        if (!body) return 0;
-        return body.childElementCount;
+      const bidLogPath = path.join(ARTIFACT_ROOT, 'bid-log.json');
+      fs.writeFileSync(bidLogPath, JSON.stringify(bidLog, jsonBigIntReplacer, 2));
+      await testInfo.attach('pregao-multiperfil-bid-log', {
+        body: JSON.stringify(bidLog, jsonBigIntReplacer, 2),
+        contentType: 'application/json',
       });
-    }, {
-      timeout: 20_000,
-      intervals: [500, 1000, 1500],
-    }).toBeGreaterThan(0);
-
-    const htmlSize = await page.content().then((html) => html.length).catch(() => 0);
-    expect(htmlSize).toBeGreaterThan(200);
-
-    console.log('\n✅ Monitor pós-disputa acessível. URL e conteúdo da página validados.');
+    } finally {
+      for (const context of contexts.reverse()) {
+        await context.close().catch(() => undefined);
+      }
+    }
   });
 });
+
+async function openLoggedActor(
+  browser: Browser,
+  actor: PregaoActor,
+  evidenceUrl: string,
+  contexts: BrowserContext[],
+  tenantId: bigint,
+): Promise<Page> {
+  const { context, page } = await openRecordedActor(browser, actor.key);
+  contexts.push(context);
+  await seedPregaoActorSession(context, actor, BASE_URL, tenantId);
+  await page.goto(evidenceUrl, { waitUntil: 'domcontentloaded', timeout: 120_000 });
+  expect(page.url(), `${actor.key} não deve voltar para login`).not.toContain('/auth/login');
+  return page;
+}
+
+async function openAdminActor(browser: Browser, contexts: BrowserContext[], f: PregaoFixture, evidenceUrl: string): Promise<Page> {
+  const { context, page } = await openRecordedActor(browser, 'admin');
+  contexts.push(context);
+  await seedPregaoActorSession(context, f.actors.admin, BASE_URL, f.tenantId);
+  await page.goto(evidenceUrl, { waitUntil: 'domcontentloaded', timeout: 120_000 });
+  expect(page.url(), 'admin da matriz multi-perfil não deve voltar para login').not.toContain('/auth/login');
+  return page;
+}
+
+async function openRecordedActor(browser: Browser, label: string): Promise<{ context: BrowserContext; page: Page }> {
+  const shouldRecordVideo = label === 'camera-monitor';
+  const context = await browser.newContext({
+    viewport: VIEWPORT,
+    ...(shouldRecordVideo ? { recordVideo: { dir: VIDEO_DIR, size: VIEWPORT } } : {}),
+  });
+  const page = await context.newPage();
+  page.on('console', (message) => {
+    if (message.type() === 'error') {
+      console.log(`[${label}] browser-error: ${message.text()}`);
+    }
+  });
+  return { context, page };
+}
+
+async function assertBuyerRoleIsolation(f: PregaoFixture): Promise<void> {
+  const buyerIds = f.actors.buyers.map((buyer) => buyer.userId).filter((id): id is bigint => Boolean(id));
+  const roleAssignments = await prisma.usersOnRoles.findMany({
+    where: { userId: { in: buyerIds } },
+    include: { Role: { select: { name: true } } },
+  });
+
+  expect(roleAssignments.some((assignment) => assignment.Role.name === 'ADMIN')).toBe(false);
+  expect(new Set(roleAssignments.filter((assignment) => assignment.Role.name === 'COMPRADOR').map((assignment) => assignment.userId.toString())).size).toBe(PREGAO_BUYER_COUNT);
+}
+
+async function assertBuyerHabilitations(f: PregaoFixture): Promise<void> {
+  const count = await prisma.auctionHabilitation.count({ where: { auctionId: f.auctionId } });
+  expect(count).toBe(PREGAO_BUYER_COUNT);
+}
+
+async function assertWinnerOnlyArtifacts(f: PregaoFixture, winnerUserId: bigint, reportId: bigint): Promise<void> {
+  const [userWin, wonLots, report] = await Promise.all([
+    prisma.userWin.findUnique({ where: { lotId: f.lotId } }),
+    prisma.wonLot.findMany({ where: { auctionId: f.auctionId } }),
+    prisma.report.findUnique({ where: { id: reportId } }),
+  ]);
+
+  expect(userWin?.userId).toBe(winnerUserId);
+  expect(wonLots).toHaveLength(1);
+  expect(report?.createdById).toBe(f.actors.analyst.userId);
+
+  const nonWinnerUserIds = f.actors.buyers
+    .map((buyer) => buyer.userId)
+    .filter((userId): userId is bigint => Boolean(userId && userId !== winnerUserId));
+  const leakedWins = await prisma.userWin.count({ where: { userId: { in: nonWinnerUserIds } } });
+  expect(leakedWins).toBe(0);
+}
+
+async function captureStep(page: Page, label: string): Promise<void> {
+  const filename = `${Date.now()}-${label.replace(/[^a-z0-9-]/gi, '_')}.png`;
+  await page.screenshot({ path: path.join(SCREENSHOT_DIR, filename), fullPage: false });
+}
+
+async function expectVisibleBidCount(page: Page, expectedMinimum: number): Promise<void> {
+  const counter = page.locator('[data-ai-id="monitor-bid-count"]');
+  await expect(counter).toBeVisible({ timeout: 30_000 });
+  await expect.poll(async () => {
+    const text = await counter.textContent().catch(() => '');
+    const [firstNumber] = text.match(/\d+/) ?? [];
+    return firstNumber ? Number(firstNumber) : 0;
+  }, {
+    timeout: 30_000,
+    intervals: [500, 1_000, 2_000],
+  }).toBeGreaterThanOrEqual(expectedMinimum);
+}
+
+function requiredFixture(): PregaoFixture {
+  if (!fixture) {
+    throw new Error('Fixture de pregão não inicializada.');
+  }
+  return fixture;
+}
+
+function ensureDirs(): void {
+  for (const directory of [ARTIFACT_ROOT, SCREENSHOT_DIR, VIDEO_DIR]) {
+    if (!fs.existsSync(directory)) {
+      fs.mkdirSync(directory, { recursive: true });
+    }
+  }
+}
+
+function jsonBigIntReplacer(_key: string, value: unknown): unknown {
+  return typeof value === 'bigint' ? value.toString() : value;
+}

--- a/tests/itsm/features/admin-lotting-modes.feature
+++ b/tests/itsm/features/admin-lotting-modes.feature
@@ -1,0 +1,17 @@
+Feature: Modos operacionais do loteamento administrativo
+  Como operador do backoffice de leilões
+  Quero alternar rapidamente entre estratégias explícitas de loteamento
+  Para manter minhas preferências operacionais persistidas sem perder o contexto transitório da sessão
+
+  Scenario: Persistir modo IA assistida com auto-save
+    Given que estou na tela administrativa de loteamento
+    When seleciono o modo "IA Assistida"
+    Then o modo ativo é exibido de forma explícita
+    And o filtro de ativos sinalizados fica habilitado
+    And um indicador visual confirma o auto-save das preferências
+
+  Scenario: Modo planilha amplia a revisão operacional
+    Given que estou na tela administrativa de loteamento
+    When seleciono o modo "Planilha Operacional"
+    Then o filtro para incluir ativos já loteados fica habilitado
+    And o resumo do modo orienta revisão em massa

--- a/tests/itsm/features/auction-audit-summary.feature
+++ b/tests/itsm/features/auction-audit-summary.feature
@@ -1,0 +1,10 @@
+Feature: Resumo mínimo de auditoria no cadastro de leilão
+  Como pessoa administradora
+  Quero ver o rastro mínimo de governança no topo do formulário
+  Para auditar rapidamente quem criou, atualizou e validou o leilão
+
+  Scenario: Formulário de edição mostra auditoria mínima e link de histórico
+    Given que estou editando um leilão já existente no admin
+    When a tela do formulário é renderizada
+    Then devo visualizar os campos Criado por, Atualizado em, Enviado para validação, Validado por e Validado em
+    And devo ter um atalho para abrir o histórico completo do leilão

--- a/tests/itsm/features/judicial-process-selector-columns.feature
+++ b/tests/itsm/features/judicial-process-selector-columns.feature
@@ -8,4 +8,14 @@ Feature: Modal compartilhado de seleção de processo judicial
     When abro o modal de seleção de processo judicial
     Then devo visualizar as colunas Processo, Comitente, Vara, Comarca e Tribunal
     And devo visualizar as colunas Partes, Eletrônico, Matrícula, Registro, Tipo de ação, Cód. CNJ e Descrição da ação
+    And devo continuar visualizando as colunas Bens e Lotes no mesmo gridFeature: Modal compartilhado de seleção de processo judicial
+  Como pessoa usuária do admin
+  Quero mais colunas no grid do processo judicial
+  Para diferenciar corretamente qual processo devo vincular ao leilão
+
+  Scenario: Modal judicial mostra colunas ampliadas sem perder bens e lotes
+    Given que estou em uma tela administrativa com seletor de processo judicial
+    When abro o modal de seleção de processo judicial
+    Then devo visualizar as colunas Processo, Comitente, Vara, Comarca e Tribunal
+    And devo visualizar as colunas Partes, Eletrônico, Matrícula, Registro, Tipo de ação, Cód. CNJ e Descrição da ação
     And devo continuar visualizando as colunas Bens e Lotes no mesmo grid

--- a/tests/itsm/features/pregao-multiperfil-video.feature
+++ b/tests/itsm/features/pregao-multiperfil-video.feature
@@ -1,0 +1,15 @@
+Feature: Pregao multi-perfil filmado
+  Como equipe de qualidade do BidExpert
+  Quero filmar um pregao com atores reais separados por perfil
+  Para comprovar que criacao, habilitacao, disputa, encerramento, laudo e cobranca seguem os contratos oficiais
+
+  Scenario: Jornada filmada com 10 compradores e vencedor unico
+    Given um agente de leilao cria um leilao e um lote em um tenant demo
+    And um administrador habilita exatamente 10 compradores para o leilao
+    And nenhum comprador possui papel de administrador
+    When o leiloeiro agenda, abre o leilao e inicia o lote em pregao pela maquina de estado
+    And os 10 compradores registram lances pelo BidEngineV2 em rodadas competitivas
+    Then o monitor filmado exibe valor atual, quantidade de lances maior que zero e lider da disputa
+    And o leiloeiro confirma como vencedor o comprador com maior lance ativo
+    And o analista emite laudo, cobranca e parcelas somente para o vencedor
+    And a evidencia Playwright contem video, prints e relatorio HTML da execucao

--- a/tests/unit/auction-audit-summary.spec.ts
+++ b/tests/unit/auction-audit-summary.spec.ts
@@ -1,0 +1,46 @@
+// @vitest-environment jsdom
+/**
+ * @fileoverview Cobertura unitária do resumo mínimo de auditoria do leilão.
+ */
+
+import React from 'react';
+import { describe, expect, it, vi } from 'vitest';
+import { render, screen } from '@testing-library/react';
+
+import { AuctionAuditSummary } from '@/components/admin/auctions/auction-audit-summary';
+
+vi.mock('next/link', () => ({
+  __esModule: true,
+  default: ({ children, href, ...props }: { children: React.ReactNode; href: string }) => (
+    React.createElement('a', { href, ...props }, children)
+  ),
+}));
+
+describe('AuctionAuditSummary', () => {
+  it('renderiza dados e atalho para o histórico completo', () => {
+    render(
+      React.createElement(AuctionAuditSummary, {
+        createdByUserId: '42',
+        updatedAt: '2026-04-27T10:00:00.000Z',
+        submittedAt: '2026-04-27T11:00:00.000Z',
+        validatedAt: '2026-04-27T12:00:00.000Z',
+        validatedBy: '84',
+        historyHref: '/admin/auctions/auction-1/history',
+      }),
+    );
+
+    expect(screen.getByText('Auditoria mínima')).toBeInTheDocument();
+    expect(screen.getByText('42')).toBeInTheDocument();
+    expect(screen.getByText('84')).toBeInTheDocument();
+    expect(screen.getByRole('link', { name: /abrir histórico completo/i })).toHaveAttribute(
+      'href',
+      '/admin/auctions/auction-1/history',
+    );
+  });
+
+  it('não renderiza quando não há dados auditáveis nem histórico', () => {
+    const { container } = render(React.createElement(AuctionAuditSummary));
+
+    expect(container).toBeEmptyDOMElement();
+  });
+});

--- a/tests/unit/bidding-eligibility.spec.ts
+++ b/tests/unit/bidding-eligibility.spec.ts
@@ -57,6 +57,20 @@ describe('getBidEligibilityState', () => {
     expect(state.reason).toBe('ALLOWED');
   });
 
+  it('libera comprador habilitado durante o pregão ao vivo', () => {
+    const state = getBidEligibilityState({
+      isAuthenticated: true,
+      lotStatus: 'EM_PREGAO',
+      auctionStatus: 'EM_PREGAO',
+      userHabilitationStatus: 'HABILITADO',
+      isAuctionHabilitated: true,
+    });
+
+    expect(state.canBid).toBe(true);
+    expect(state.canPlaceMaxBid).toBe(true);
+    expect(state.reason).toBe('ALLOWED');
+  });
+
   it('bloqueia lances quando o lote não está aberto', () => {
     const state = getBidEligibilityState({
       isAuthenticated: true,

--- a/tests/unit/judicial-process-selector-config.spec.ts
+++ b/tests/unit/judicial-process-selector-config.spec.ts
@@ -54,7 +54,6 @@ describe('judicial-process-selector-config', () => {
         sellerName: 'Massa Falida XPTO',
         lotCount: 5,
         assetCount: 2,
-        auctions: [],
         lots: [],
         assets: [],
       },

--- a/tests/unit/lotting-preferences.spec.ts
+++ b/tests/unit/lotting-preferences.spec.ts
@@ -1,0 +1,69 @@
+/**
+ * @fileoverview Cobre a persistência local das preferências operacionais do loteamento.
+ */
+
+import { describe, expect, it } from 'vitest';
+
+import {
+  LOTTING_PREFERENCES_STORAGE_KEY,
+  getDefaultLottingFilters,
+  loadLottingPreferences,
+  normalizeLottingPreferences,
+  saveLottingPreferences,
+} from '@/lib/lotting/preferences';
+
+describe('lotting preferences', () => {
+  it('normaliza payload inválido para defaults seguros', () => {
+    const normalized = normalizeLottingPreferences({
+      mode: 'invalid-mode',
+      filters: {
+        includeGroupedAssets: 'sim',
+        onlyHighlighted: true,
+        minimumValuation: -500,
+        auctionId: 'should-not-persist',
+        judicialProcessId: 'should-not-persist',
+      },
+    });
+
+    expect(normalized.mode).toBe('quick');
+    expect(normalized.filters).toEqual({
+      includeGroupedAssets: false,
+      onlyHighlighted: true,
+      minimumValuation: 0,
+    });
+  });
+
+  it('salva e recarrega apenas preferências operacionais', () => {
+    const memoryStorage = new Map<string, string>();
+
+    const storage = {
+      getItem: (key: string) => memoryStorage.get(key) ?? null,
+      setItem: (key: string, value: string) => {
+        memoryStorage.set(key, value);
+      },
+    };
+
+    const saved = saveLottingPreferences(
+      {
+        mode: 'ai',
+        filters: {
+          ...getDefaultLottingFilters(),
+          includeGroupedAssets: true,
+          onlyHighlighted: true,
+          minimumValuation: 250000,
+          auctionId: 'auction-1',
+          judicialProcessId: 'process-1',
+        },
+      },
+      storage,
+    );
+
+    expect(saved.updatedAt).toBeTruthy();
+
+    const rawStored = JSON.parse(memoryStorage.get(LOTTING_PREFERENCES_STORAGE_KEY) ?? '{}');
+    expect(rawStored.filters.auctionId).toBeUndefined();
+    expect(rawStored.filters.judicialProcessId).toBeUndefined();
+
+    expect(loadLottingPreferences(storage)).toEqual(saved);
+  });
+});

--- a/tests/unit/pregao-multiperfil-fixture.spec.ts
+++ b/tests/unit/pregao-multiperfil-fixture.spec.ts
@@ -1,0 +1,45 @@
+/**
+ * @fileoverview Testes unitários das regras puras da fixture de pregão multi-perfil.
+ */
+
+import { describe, expect, it } from 'vitest';
+
+import {
+  PREGAO_BID_INCREMENT,
+  PREGAO_BUYER_COUNT,
+  PREGAO_INITIAL_PRICE,
+  buildPregaoActorMatrix,
+  buildPregaoBidSchedule,
+  groupPregaoScheduleByRound,
+  resolvePregaoWinner,
+} from '../e2e/helpers/pregao-multiperfil-fixture';
+
+describe('pregao-multiperfil fixture helpers', () => {
+  it('cria 10 compradores independentes sem papel de administrador', () => {
+    const matrix = buildPregaoActorMatrix('unit-run');
+
+    expect(matrix.buyers).toHaveLength(PREGAO_BUYER_COUNT);
+    expect(new Set(matrix.buyers.map((buyer) => buyer.email)).size).toBe(PREGAO_BUYER_COUNT);
+    expect(matrix.buyers.every((buyer) => buyer.roles.includes('COMPRADOR'))).toBe(true);
+    expect(matrix.buyers.some((buyer) => buyer.roles.includes('ADMIN'))).toBe(false);
+  });
+
+  it('calcula vencedor pelo maior lance planejado', () => {
+    const matrix = buildPregaoActorMatrix('unit-run');
+    const schedule = buildPregaoBidSchedule(matrix.buyers, { runId: 'unit-run', rounds: 2 });
+    const winner = resolvePregaoWinner(schedule);
+
+    expect(schedule).toHaveLength(PREGAO_BUYER_COUNT * 2);
+    expect(winner.buyerNumber).toBe(PREGAO_BUYER_COUNT);
+    expect(winner.amount).toBe(PREGAO_INITIAL_PRICE + PREGAO_BID_INCREMENT * PREGAO_BUYER_COUNT * 2);
+  });
+
+  it('agrupa a disputa por rodadas completas de compradores', () => {
+    const matrix = buildPregaoActorMatrix('unit-run');
+    const schedule = buildPregaoBidSchedule(matrix.buyers, { runId: 'unit-run', rounds: 3 });
+    const groups = groupPregaoScheduleByRound(schedule);
+
+    expect(groups).toHaveLength(3);
+    expect(groups.every((group) => group.length === PREGAO_BUYER_COUNT)).toBe(true);
+  });
+});


### PR DESCRIPTION
## Resumo
- Implementa o fluxo filmado de pregão multi-perfil com agente de leilão, admin, leiloeiro, analista e 10 compradores isolados.
- Centraliza fixtures determinísticas para criação/habilitação/lances/finalização e mantém o pregão passando pelo BidEngineV2 e state machines oficiais.
- Corrige o contador visual do monitor para consolidar realtime, histórico e estado persistido durante o pregão ao vivo.
- Documenta a regra RN-017A e adiciona cenário BDD rastreável.

## Validações locais
- `npm ci` passou.
- `npm run typecheck` passou.
- Vitest focado passou: 9/9.
- Playwright filmado passou: 1/1, cenário `Pregão multi-perfil filmado`, com 10 compradores, 30 lances, vencedor único e monitor final coerente (`R$20.000,00`, `30 LANCES`).
- `npm run build` passou após limpeza de artefatos `.next` gerados; avisos `force-dynamic` esperados em rotas dinâmicas.

## Evidências Playwright
- Relatório local: `test-results/pregao-video/report/index.html`.
- Resultado JSON: `test-results/pregao-video/results.json`.
- Bid log: `test-results/pregao-video/bid-log.json`.
- Screenshots locais: `test-results/pregao-video/screenshots/*`, incluindo `08-camera-vencedor-confirmado.png` e `09-analista-laudo-cobranca.png`.

## Observações
- Nenhuma alteração em schema Prisma, seeds globais ou governança de documentos de leilão.
- Evidências locais não foram commitadas; a CI/Playwright deve publicar artifacts no PR.